### PR TITLE
Add RegCopy command

### DIFF
--- a/PEBakery/Core/CodeCommand.cs
+++ b/PEBakery/Core/CodeCommand.cs
@@ -53,7 +53,7 @@ namespace PEBakery.Core
         DirCopy = 120, DirDelete, DirMove, DirMake, DirSize,
         PathMove = 160,
         // 02 Registry
-        RegHiveLoad = 200, RegHiveUnload, RegRead, RegWrite, RegDelete, RegMulti, RegImport, RegExport,
+        RegHiveLoad = 200, RegHiveUnload, RegRead, RegWrite, RegDelete, RegMulti, RegImport, RegExport, RegCopy,
         RegWriteLegacy = 260,
         // 03 Text
         TXTAddLine = 300, TXTDelLine, TXTReplace, TXTDelSpaces, TXTDelEmptyLines,
@@ -750,6 +750,31 @@ namespace PEBakery.Core
         {
             string HKeyStr = RegistryHelper.RegKeyToString(HKey);
             return $"{HKeyStr},{KeyPath},{RegFile}";
+        }
+    }
+
+    [Serializable]
+    public class CodeInfo_RegCopy : CodeInfo
+    { // RegCopy,<SrcKey>,<SrcKeyPath>,<DestKey>,<DestKeyPath>
+        [NonSerialized]
+        public RegistryKey HSrcKey;
+        public string SrcKeyPath;
+        public RegistryKey HDestKey;
+        public string DestKeyPath;
+
+        public CodeInfo_RegCopy(RegistryKey hSrcKey, string srcKeyPath, RegistryKey hDestKey, string destKeyPath)
+        {
+            HSrcKey = hSrcKey;
+            SrcKeyPath = srcKeyPath;
+            HDestKey = hDestKey;
+            DestKeyPath = destKeyPath;
+        }
+
+        public override string ToString()
+        {
+            string HKeySrcStr = RegistryHelper.RegKeyToString(HSrcKey);
+            string HKeyDestStr = RegistryHelper.RegKeyToString(HDestKey);
+            return $"{HKeySrcStr},{SrcKeyPath},{HKeyDestStr},{DestKeyPath}";
         }
     }
     #endregion

--- a/PEBakery/Core/CodeParser.cs
+++ b/PEBakery/Core/CodeParser.cs
@@ -733,6 +733,17 @@ namespace PEBakery.Core
 
                         return new CodeInfo_RegExport(hKey, args[1], args[2]);
                     }
+                case CodeType.RegCopy:
+                    { // RegCopy,<SrcKey>,<SrcKeyPath>,<DestKey>,<DestKeyPath>
+                        const int argCount = 4;
+                        if (args.Count != argCount)
+                            throw new InvalidCommandException($"Command [{type}] must have [{argCount}] arguments", rawCode);
+
+                        RegistryKey hSrcKey = RegistryHelper.ParseStringToRegKey(args[0]);
+                        RegistryKey hDestKey = RegistryHelper.ParseStringToRegKey(args[2]);
+
+                        return new CodeInfo_RegCopy(hSrcKey, args[1], hDestKey, args[3]);
+                    }
                 #endregion
                 #region 03 Text
                 case CodeType.TXTAddLine:

--- a/PEBakery/Core/Engine.cs
+++ b/PEBakery/Core/Engine.cs
@@ -472,6 +472,9 @@ namespace PEBakery.Core
                     case CodeType.RegExport:
                         logs.AddRange(CommandRegistry.RegExport(s, cmd));
                         break;
+                    case CodeType.RegCopy:
+                        logs.AddRange(CommandRegistry.RegCopy(s, cmd));
+                        break;
                     #endregion
                     #region 03 Text
                     case CodeType.TXTAddLine:


### PR DESCRIPTION
Coping registry keys via `REG.exe COPY` command in is extensively used by 'PE SE' projects, as well as my personal project and ChrisR's new project. A native command to facilitate this feature would be convenient.