### PR TITLE
Assign ownership of About,Setting,Log,Utilities windows to MainWindow…

### DIFF
--- a/PEBakery/WPF/AboutWindow.xaml
+++ b/PEBakery/WPF/AboutWindow.xaml
@@ -37,7 +37,8 @@
         FontFamily="Segoe UI"
         ResizeMode="NoResize"
         Title="About PEBakery"
-        Width="600" Height="480">
+        Width="600" Height="480"
+        WindowStartupLocation="CenterOwner">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition/>

--- a/PEBakery/WPF/LogWindow.xaml
+++ b/PEBakery/WPF/LogWindow.xaml
@@ -40,6 +40,7 @@
         Title="PEBakery Log Viewer"
         Width="900" Height="640"
         MinWidth="640" MinHeight="480"
+        WindowStartupLocation="CenterOwner"
         d:DataContext="{d:DesignInstance Type=local:LogViewModel}">
     <Window.Resources>
         <Style TargetType="ListViewItem">

--- a/PEBakery/WPF/MainWindow.xaml.cs
+++ b/PEBakery/WPF/MainWindow.xaml.cs
@@ -753,6 +753,7 @@ namespace PEBakery.WPF
             bool oldScriptEnableCache = Setting.Script_EnableCache;
 
             SettingWindow dialog = new SettingWindow(Setting);
+            dialog.Owner = this;
             bool? result = dialog.ShowDialog();
             if (result == true)
             {
@@ -779,6 +780,7 @@ namespace PEBakery.WPF
                 return;
 
             UtilityDialog = new UtilityWindow(Setting.Interface_MonospaceFont);
+            UtilityDialog.Owner = this;
             UtilityDialog.Show();
         }
 
@@ -787,6 +789,7 @@ namespace PEBakery.WPF
             if (LogWindow.Count == 0)
             {
                 LogDialog = new LogWindow();
+                LogDialog.Owner = this;
                 LogDialog.Show();
             }
         }
@@ -813,6 +816,7 @@ namespace PEBakery.WPF
         private void AboutButton_Click(object sender, RoutedEventArgs e)
         {
             AboutWindow dialog = new AboutWindow(Setting.Interface_MonospaceFont);
+            dialog.Owner = this;
             dialog.ShowDialog();
         }
         #endregion

--- a/PEBakery/WPF/SettingWindow.xaml
+++ b/PEBakery/WPF/SettingWindow.xaml
@@ -39,6 +39,7 @@
         Loaded="Window_Loaded"
         Title="PEBakery Setting"
         Width="600" Height="480"
+        WindowStartupLocation="CenterOwner"
         d:DataContext="{d:DesignInstance Type=local:SettingViewModel}">
     <Grid>
         <Grid.RowDefinitions>

--- a/PEBakery/WPF/UtilityWindow.xaml
+++ b/PEBakery/WPF/UtilityWindow.xaml
@@ -39,6 +39,7 @@
         Closed="Window_Closed"
         Width="800" Height="640"
         MinWidth="640" MinHeight="480"
+        WindowStartupLocation="CenterOwner"
         d:DataContext="{d:DesignInstance Type=local:UtilityViewModel}">
     <Window.CommandBindings>
         <CommandBinding Command="ApplicationCommands.Save"


### PR DESCRIPTION
… and center on MainWindow upon load.

Sub windows will open centered on MainWindow instead of somewhere up in the top left of the screen.
Some considerations to be made are:

1. With sub windows being assigned as children to MainWindow they can no longer be covered up by the main window. This is desirable in most cases.
1. sub windows will be minimized along with the main window. generally this should be desirable. 

Do you see any issues with this in regards to the utilities or log window? Is there a valid use for minimizing the main window but leaving log/utilities open? If so we can remove ownership of the sub window and use `WindowStartupLocation="CenterScreen">` to open center regradless of MainWindow position or calculate the startupLocation via the MainWindow coordinates (in the event the user has the mainwindow somewhere else)