### PR TITLE
Customizable columns/visibility in full log viewer

### DIFF
--- a/PEBakery/WPF/Converter.cs
+++ b/PEBakery/WPF/Converter.cs
@@ -327,29 +327,15 @@ namespace PEBakery.WPF
         }
     }
 
-    public class ScriptSourceColumnWidthConverter : IValueConverter
+    public class GridViewColumnWidthConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value == null || parameter == null)
                 return string.Empty;
-
-            bool showScriptOrigin = (bool)value;
-            int columnType = (int)parameter;
-            if (showScriptOrigin)
-            {
-                if (columnType == 0) // Time
-                    return 0;
-                else // ScriptOrigin
-                    return 135; 
-            }
-            else
-            {
-                if (columnType == 0) // Time
-                    return 135;
-                else // ScriptOrigin
-                    return 0;
-            }
+            if (value is bool visible && parameter is int width)
+                return visible ? width : 0;
+            return 0;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/PEBakery/WPF/LogWindow.xaml
+++ b/PEBakery/WPF/LogWindow.xaml
@@ -61,6 +61,10 @@
                         Command="local:LogViewCommands.ExportCommand"
                         CanExecute="ExportCommand_CanExecute"
                         Executed="ExportCommand_Executed"/>
+        <CommandBinding x:Name="LogOptionsCommand"
+                        Command="local:LogViewCommands.LogOptionsCommand"
+                        CanExecute="LogOptionsCommand_CanExecute"
+                        Executed="LogOptionsCommand_Executed"/>
     </Window.CommandBindings>
     <Window.Resources>
         <Style TargetType="ListViewItem">
@@ -234,10 +238,10 @@
                                         <GridViewColumn Header="Time"
                                                         DisplayMemberBinding="{Binding Time, Converter={StaticResource LocalTimeToStrConverter}}">
                                             <GridViewColumn.Width>
-                                                <Binding Path="BuildLogShowScriptOrigin"
+                                                <Binding Path="BuildLogShowTime"
                                                          Converter="{StaticResource ScriptSourceColumnWidthConverter}">
                                                     <Binding.ConverterParameter>
-                                                        <s:Int32>0</s:Int32>
+                                                        <s:Int32>1</s:Int32>
                                                     </Binding.ConverterParameter>
                                                     <Binding.FallbackValue>
                                                         <s:Boolean>false</s:Boolean>
@@ -266,23 +270,95 @@
                                             </GridViewColumn.DisplayMemberBinding>
                                         </GridViewColumn>
                                         <GridViewColumn Header="Depth"
-                                                        Width="35"
-                                                        DisplayMemberBinding="{Binding Depth, Mode=OneWay}" />
+                                                        DisplayMemberBinding="{Binding Depth, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowDepth"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>35</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Boolean>false</s:Boolean>
+                                                    </Binding.FallbackValue>
+                                                </Binding>
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
                                         <GridViewColumn Header="State"
-                                                        Width="55"
-                                                        DisplayMemberBinding="{Binding State, Converter={StaticResource LogStateToStrConverter}, Mode=OneWay}" />
+                                                        DisplayMemberBinding="{Binding State, Converter={StaticResource LogStateToStrConverter}, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowState"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>55</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Boolean>false</s:Boolean>
+                                                    </Binding.FallbackValue>
+                                                </Binding>
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
                                         <GridViewColumn Header="Line#"
-                                                        Width="40"
-                                                        DisplayMemberBinding="{Binding LineIdx, Converter={StaticResource LineIdxToStrConverter}, Mode=OneWay}" />
+                                                        DisplayMemberBinding="{Binding LineIdx, Converter={StaticResource LineIdxToStrConverter}, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowLineNumber"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>40</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Boolean>false</s:Boolean>
+                                                    </Binding.FallbackValue>
+                                                </Binding>
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
                                         <GridViewColumn Header="Message"
-                                                        Width="340" 
-                                                        DisplayMemberBinding="{Binding Message, Mode=OneWay}" />
+                                                        DisplayMemberBinding="{Binding Message, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowMessage"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>340</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Boolean>false</s:Boolean>
+                                                    </Binding.FallbackValue>
+                                                </Binding>
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
                                         <GridViewColumn Header="RawCode"
-                                                        Width="175"
-                                                        DisplayMemberBinding="{Binding RawCode, Mode=OneWay}" />
+                                                        DisplayMemberBinding="{Binding RawCode, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowRawCode"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>175</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Boolean>false</s:Boolean>
+                                                    </Binding.FallbackValue>
+                                                </Binding>
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
                                         <GridViewColumn Header="Flags"
-                                                        Width="35"
-                                                        DisplayMemberBinding="{Binding Flags, Converter={StaticResource BuildLogFlagToStrConverter}, Mode=OneWay}" />
+                                                        DisplayMemberBinding="{Binding Flags, Converter={StaticResource BuildLogFlagToStrConverter}, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowFlags"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>35</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Boolean>false</s:Boolean>
+                                                    </Binding.FallbackValue>
+                                                </Binding>                             
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
                                     </GridView>
                                 </ListView.View>
                                 <ListView.ContextMenu>
@@ -361,30 +437,32 @@
                     Command="local:LogViewCommands.ExportCommand"
                     AutomationProperties.Name="{Binding RelativeSource={RelativeSource Self}, Path=Command.Text}"
                     Content="Export"/>
-            <StackPanel Orientation="Horizontal" 
-                        Visibility="{Binding BuildLogSelected}">
-                <CheckBox DockPanel.Dock="Left"
-                          HorizontalAlignment="Left"
-                          VerticalAlignment="Center"
-                          VerticalContentAlignment="Center"
-                          Margin="0, 0, 5, 0"
-                          IsChecked="{Binding BuildLogShowComments}"
-                          Content="Show Comments"/>
-                <CheckBox DockPanel.Dock="Left"
-                          HorizontalAlignment="Left"
-                          VerticalAlignment="Center"
-                          VerticalContentAlignment="Center"
-                          Margin="0, 0, 5, 0"
-                          IsChecked="{Binding BuildLogShowMacros}"
-                          Content="Show Macros"/>
-                <CheckBox DockPanel.Dock="Left"
-                          HorizontalAlignment="Left"
-                          VerticalAlignment="Center"
-                          VerticalContentAlignment="Center"
-                          Margin="0, 0, 5, 0"
-                          IsChecked="{Binding BuildLogShowScriptOrigin}"
-                          Content="Show Script Origin "/>
-            </StackPanel>
+            <Button DockPanel.Dock="Left"
+                    HorizontalAlignment="Left"
+                    Width="100"
+                    Margin="0, 0, 10, 0"
+                    Command="local:LogViewCommands.LogOptionsCommand"
+                    AutomationProperties.Name="{Binding RelativeSource={RelativeSource Self}, Path=Command.Text}"
+                    Visibility="{Binding BuildLogSelected}"
+                    Content="Options">
+                <Button.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Log Options" IsEnabled="False" />
+                        <CheckBox IsChecked="{Binding BuildLogShowComments}" Content="Show Comments" />
+                        <CheckBox IsChecked="{Binding BuildLogShowMacros}" Content="Show Macros" />
+                        <Separator Visibility="{Binding BuildLogFullLogSelected}" />
+                        <MenuItem Header="Show Columns" IsEnabled="False" />
+                        <CheckBox IsChecked="{Binding BuildLogShowDepth}" Content="Depth" />
+                        <CheckBox IsChecked="{Binding BuildLogShowFlags}" Content="Flags" />
+                        <CheckBox IsChecked="{Binding BuildLogShowLineNumber}" Content="Line #" />
+                        <CheckBox IsChecked="{Binding BuildLogShowMessage}" Content="Message" />
+                        <CheckBox IsChecked="{Binding BuildLogShowScriptOrigin}" Content="Script Orgin" />
+                        <CheckBox IsChecked="{Binding BuildLogShowState}" Content="State" />
+                        <CheckBox IsChecked="{Binding BuildLogShowTime}" Content="Time" />
+                        <CheckBox IsChecked="{Binding BuildLogShowRawCode}" Content="Raw Code" />
+                    </ContextMenu>
+                </Button.ContextMenu>
+            </Button>
         </DockPanel>
     </Grid>
 </Window>

--- a/PEBakery/WPF/LogWindow.xaml
+++ b/PEBakery/WPF/LogWindow.xaml
@@ -98,7 +98,7 @@
         <local:LogStateToStrConverter x:Key="LogStateToStrConverter"/>
         <local:LineIdxToStrConverter x:Key="LineIdxToStrConverter"/>
         <local:RefScriptIdToTitleConverter x:Key="RefScriptIdToTitleConverter"/>
-        <local:ScriptSourceColumnWidthConverter x:Key="ScriptSourceColumnWidthConverter"/>
+        <local:GridViewColumnWidthConverter x:Key="GridViewColumnWidthConverter"/>
         <local:BuildLogFlagToStrConverter x:Key="BuildLogFlagToStrConverter"/>
     </Window.Resources>
     <Grid>
@@ -239,12 +239,12 @@
                                                         DisplayMemberBinding="{Binding Time, Converter={StaticResource LocalTimeToStrConverter}}">
                                             <GridViewColumn.Width>
                                                 <Binding Path="BuildLogShowTime"
-                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                         Converter="{StaticResource GridViewColumnWidthConverter}">
                                                     <Binding.ConverterParameter>
-                                                        <s:Int32>1</s:Int32>
+                                                        <s:Int32>135</s:Int32>
                                                     </Binding.ConverterParameter>
                                                     <Binding.FallbackValue>
-                                                        <s:Boolean>false</s:Boolean>
+                                                        <s:Int32>135</s:Int32>
                                                     </Binding.FallbackValue>
                                                 </Binding>
                                             </GridViewColumn.Width>
@@ -253,12 +253,12 @@
                                             <GridViewColumn.Width>
                                                 <Binding Path="BuildLogShowScriptOrigin"
                                                          Mode="OneWay"
-                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                         Converter="{StaticResource GridViewColumnWidthConverter}">
                                                     <Binding.ConverterParameter>
-                                                        <s:Int32>1</s:Int32>
+                                                        <s:Int32>135</s:Int32>
                                                     </Binding.ConverterParameter>
                                                     <Binding.FallbackValue>
-                                                        <s:Boolean>false</s:Boolean>
+                                                        <s:Int32>135</s:Int32>
                                                     </Binding.FallbackValue>
                                                 </Binding>
                                             </GridViewColumn.Width>
@@ -274,12 +274,12 @@
                                             <GridViewColumn.Width>
                                                 <Binding Path="BuildLogShowDepth"
                                                          Mode="OneWay"
-                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                         Converter="{StaticResource GridViewColumnWidthConverter}">
                                                     <Binding.ConverterParameter>
                                                         <s:Int32>35</s:Int32>
                                                     </Binding.ConverterParameter>
                                                     <Binding.FallbackValue>
-                                                        <s:Boolean>false</s:Boolean>
+                                                        <s:Int32>35</s:Int32>
                                                     </Binding.FallbackValue>
                                                 </Binding>
                                             </GridViewColumn.Width>
@@ -289,57 +289,12 @@
                                             <GridViewColumn.Width>
                                                 <Binding Path="BuildLogShowState"
                                                          Mode="OneWay"
-                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                         Converter="{StaticResource GridViewColumnWidthConverter}">
                                                     <Binding.ConverterParameter>
                                                         <s:Int32>55</s:Int32>
                                                     </Binding.ConverterParameter>
                                                     <Binding.FallbackValue>
-                                                        <s:Boolean>false</s:Boolean>
-                                                    </Binding.FallbackValue>
-                                                </Binding>
-                                            </GridViewColumn.Width>
-                                        </GridViewColumn>
-                                        <GridViewColumn Header="Line#"
-                                                        DisplayMemberBinding="{Binding LineIdx, Converter={StaticResource LineIdxToStrConverter}, Mode=OneWay}">
-                                            <GridViewColumn.Width>
-                                                <Binding Path="BuildLogShowLineNumber"
-                                                         Mode="OneWay"
-                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
-                                                    <Binding.ConverterParameter>
-                                                        <s:Int32>40</s:Int32>
-                                                    </Binding.ConverterParameter>
-                                                    <Binding.FallbackValue>
-                                                        <s:Boolean>false</s:Boolean>
-                                                    </Binding.FallbackValue>
-                                                </Binding>
-                                            </GridViewColumn.Width>
-                                        </GridViewColumn>
-                                        <GridViewColumn Header="Message"
-                                                        DisplayMemberBinding="{Binding Message, Mode=OneWay}">
-                                            <GridViewColumn.Width>
-                                                <Binding Path="BuildLogShowMessage"
-                                                         Mode="OneWay"
-                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
-                                                    <Binding.ConverterParameter>
-                                                        <s:Int32>340</s:Int32>
-                                                    </Binding.ConverterParameter>
-                                                    <Binding.FallbackValue>
-                                                        <s:Boolean>false</s:Boolean>
-                                                    </Binding.FallbackValue>
-                                                </Binding>
-                                            </GridViewColumn.Width>
-                                        </GridViewColumn>
-                                        <GridViewColumn Header="RawCode"
-                                                        DisplayMemberBinding="{Binding RawCode, Mode=OneWay}">
-                                            <GridViewColumn.Width>
-                                                <Binding Path="BuildLogShowRawCode"
-                                                         Mode="OneWay"
-                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
-                                                    <Binding.ConverterParameter>
-                                                        <s:Int32>175</s:Int32>
-                                                    </Binding.ConverterParameter>
-                                                    <Binding.FallbackValue>
-                                                        <s:Boolean>false</s:Boolean>
+                                                        <s:Int32>55</s:Int32>
                                                     </Binding.FallbackValue>
                                                 </Binding>
                                             </GridViewColumn.Width>
@@ -349,14 +304,59 @@
                                             <GridViewColumn.Width>
                                                 <Binding Path="BuildLogShowFlags"
                                                          Mode="OneWay"
-                                                         Converter="{StaticResource ScriptSourceColumnWidthConverter}">
+                                                         Converter="{StaticResource GridViewColumnWidthConverter}">
                                                     <Binding.ConverterParameter>
                                                         <s:Int32>35</s:Int32>
                                                     </Binding.ConverterParameter>
                                                     <Binding.FallbackValue>
-                                                        <s:Boolean>false</s:Boolean>
+                                                        <s:Int32>35</s:Int32>
                                                     </Binding.FallbackValue>
-                                                </Binding>                             
+                                                </Binding>
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
+                                        <GridViewColumn Header="Message"
+                                                        DisplayMemberBinding="{Binding Message, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowMessage"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource GridViewColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>340</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Int32>340</s:Int32>
+                                                    </Binding.FallbackValue>
+                                                </Binding>
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
+                                        <GridViewColumn Header="RawCode"
+                                                        DisplayMemberBinding="{Binding RawCode, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowRawCode"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource GridViewColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>175</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Int32>175</s:Int32>
+                                                    </Binding.FallbackValue>
+                                                </Binding>
+                                            </GridViewColumn.Width>
+                                        </GridViewColumn>
+                                        <GridViewColumn Header="Line#"
+                                                        DisplayMemberBinding="{Binding LineIdx, Converter={StaticResource LineIdxToStrConverter}, Mode=OneWay}">
+                                            <GridViewColumn.Width>
+                                                <Binding Path="BuildLogShowLineNumber"
+                                                         Mode="OneWay"
+                                                         Converter="{StaticResource GridViewColumnWidthConverter}">
+                                                    <Binding.ConverterParameter>
+                                                        <s:Int32>40</s:Int32>
+                                                    </Binding.ConverterParameter>
+                                                    <Binding.FallbackValue>
+                                                        <s:Int32>40</s:Int32>
+                                                    </Binding.FallbackValue>
+                                                </Binding>
                                             </GridViewColumn.Width>
                                         </GridViewColumn>
                                     </GridView>
@@ -452,14 +452,14 @@
                         <CheckBox IsChecked="{Binding BuildLogShowMacros}" Content="Show Macros" />
                         <Separator Visibility="{Binding BuildLogFullLogSelected}" />
                         <MenuItem Header="Show Columns" IsEnabled="False" />
-                        <CheckBox IsChecked="{Binding BuildLogShowDepth}" Content="Depth" />
-                        <CheckBox IsChecked="{Binding BuildLogShowFlags}" Content="Flags" />
-                        <CheckBox IsChecked="{Binding BuildLogShowLineNumber}" Content="Line #" />
-                        <CheckBox IsChecked="{Binding BuildLogShowMessage}" Content="Message" />
-                        <CheckBox IsChecked="{Binding BuildLogShowScriptOrigin}" Content="Script Orgin" />
-                        <CheckBox IsChecked="{Binding BuildLogShowState}" Content="State" />
                         <CheckBox IsChecked="{Binding BuildLogShowTime}" Content="Time" />
+                        <CheckBox IsChecked="{Binding BuildLogShowScriptOrigin}" Content="Script Origin" />
+                        <CheckBox IsChecked="{Binding BuildLogShowDepth}" Content="Depth" />
+                        <CheckBox IsChecked="{Binding BuildLogShowState}" Content="State" />
+                        <CheckBox IsChecked="{Binding BuildLogShowFlags}" Content="Flags" />
+                        <CheckBox IsChecked="{Binding BuildLogShowMessage}" Content="Message" />
                         <CheckBox IsChecked="{Binding BuildLogShowRawCode}" Content="Raw Code" />
+                        <CheckBox IsChecked="{Binding BuildLogShowLineNumber}" Content="Line #" />
                     </ContextMenu>
                 </Button.ContextMenu>
             </Button>

--- a/PEBakery/WPF/LogWindow.xaml.cs
+++ b/PEBakery/WPF/LogWindow.xaml.cs
@@ -314,6 +314,21 @@ namespace PEBakery.WPF
         {
             Close();
         }
+
+        private void LogOptionsCommand_CanExecute(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = _m != null && _m.CanExecuteCommand;
+        }
+
+        private void LogOptionsCommand_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            // Open Context Menu
+            if (e.Source is Button button && button.ContextMenu is ContextMenu menu)
+            {
+                menu.PlacementTarget = button;
+                menu.IsOpen = true;
+            }
+        }
         #endregion
     }
 
@@ -672,6 +687,42 @@ namespace PEBakery.WPF
             }
         }
 
+        private bool _buildLogShowDepth = true;
+        public bool BuildLogShowDepth
+        {
+            get => _buildLogShowDepth;
+            set
+            {
+                _buildLogShowDepth = value;
+                OnPropertyUpdate();
+                RefreshBuildLog(SelectedScriptIndex);
+            }
+        }
+
+        private bool _buildLogShowFlags = true;
+        public bool BuildLogShowFlags
+        {
+            get => _buildLogShowFlags;
+            set
+            {
+                _buildLogShowFlags = value;
+                OnPropertyUpdate();
+                RefreshBuildLog(SelectedScriptIndex);
+            }
+        }
+
+        private bool _buildLogShowLineNumber = true;
+        public bool BuildLogShowLineNumber
+        {
+            get => _buildLogShowLineNumber;
+            set
+            {
+                _buildLogShowLineNumber = value;
+                OnPropertyUpdate();
+                RefreshBuildLog(SelectedScriptIndex);
+            }
+        }
+               
         private bool _buildLogShowMacros = true;
         public bool BuildLogShowMacros
         {
@@ -684,6 +735,18 @@ namespace PEBakery.WPF
             }
         }
 
+        private bool _buildLogShowMessage = true;
+        public bool BuildLogShowMessage
+        {
+            get => _buildLogShowMessage;
+            set
+            {
+                _buildLogShowMessage = value;
+                OnPropertyUpdate();
+                RefreshBuildLog(SelectedScriptIndex);
+            }
+        }
+
         private bool _buildLogShowScriptOrigin = false;
         public bool BuildLogShowScriptOrigin
         {
@@ -691,6 +754,42 @@ namespace PEBakery.WPF
             set
             {
                 _buildLogShowScriptOrigin = value;
+                OnPropertyUpdate();
+                RefreshBuildLog(SelectedScriptIndex);
+            }
+        }
+
+        private bool _buildLogShowState = true;
+        public bool BuildLogShowState
+        {
+            get => _buildLogShowState;
+            set
+            {
+                _buildLogShowState = value;
+                OnPropertyUpdate();
+                RefreshBuildLog(SelectedScriptIndex);
+            }
+        }
+
+        private bool _buildLogShowTime = true;
+        public bool BuildLogShowTime
+        {
+            get => _buildLogShowTime;
+            set
+            {
+                _buildLogShowTime = value;
+                OnPropertyUpdate();
+                RefreshBuildLog(SelectedScriptIndex);
+            }
+        }
+
+        private bool _buildLogShowRawCode = true;
+        public bool BuildLogShowRawCode
+        {
+            get => _buildLogShowRawCode;
+            set
+            {
+                _buildLogShowRawCode = value;
                 OnPropertyUpdate();
                 RefreshBuildLog(SelectedScriptIndex);
             }
@@ -719,6 +818,7 @@ namespace PEBakery.WPF
             });
         public static readonly RoutedCommand ClearCommand = new RoutedUICommand("Clear logs", "Clear", typeof(LogViewCommands));
         public static readonly RoutedCommand ExportCommand = new RoutedUICommand("Export logs", "Export", typeof(LogViewCommands));
+        public static readonly RoutedCommand LogOptionsCommand = new RoutedUICommand("Log Options", "Options", typeof(LogViewCommands));
         public static readonly RoutedCommand CloseCommand = new RoutedUICommand("Close", "Close", typeof(LogViewCommands));
         #endregion
     }


### PR DESCRIPTION
In the LogWindow, full log viewer's column 's visibilities are now customizable.
Original work by @homes32.