### PR TITLE
Default save as filename

### DIFF
--- a/PEBakery.Core.Tests/EncodedFileTests.cs
+++ b/PEBakery.Core.Tests/EncodedFileTests.cs
@@ -401,7 +401,7 @@ namespace PEBakery.Core.Tests
             Script sc = s.Project.LoadScriptRuntime(scPath, new LoadScriptRuntimeOptions());
 
             byte[] extractDigest;
-            using (MemoryStream ms = EncodedFile.ExtractLogo(sc, out ImageHelper.ImageFormat type))
+            using (MemoryStream ms = EncodedFile.ExtractLogo(sc, out ImageHelper.ImageFormat type, out _))
             {
                 Assert.IsTrue(type == ImageHelper.ImageFormat.Jpg);
                 extractDigest = HashHelper.GetHash(HashHelper.HashType.SHA256, ms);

--- a/PEBakery.Core/EncodedFile.cs
+++ b/PEBakery.Core/EncodedFile.cs
@@ -532,10 +532,10 @@ namespace PEBakery.Core
 
         public static Task<MemoryStream> ExtractLogoAsync(Script sc)
         {
-            return Task.Run(() => ExtractLogo(sc, out _));
+            return Task.Run(() => ExtractLogo(sc, out _, out _));
         }
 
-        public static MemoryStream ExtractLogo(Script sc, out ImageHelper.ImageFormat type)
+        public static MemoryStream ExtractLogo(Script sc, out ImageHelper.ImageFormat type, out string filename)
         {
             if (sc == null)
                 throw new ArgumentNullException(nameof(sc));
@@ -548,6 +548,7 @@ namespace PEBakery.Core
                 throw new InvalidOperationException($"Logo does not exist in [{sc.Title}]");
 
             string logoFile = fileDict["Logo"];
+            filename = logoFile;
             if (!ImageHelper.GetImageFormat(logoFile, out type))
                 throw new ArgumentException($"Image [{Path.GetExtension(logoFile)}] is not supported");
 

--- a/PEBakery.Core/ViewModels/MainViewModel.cs
+++ b/PEBakery.Core/ViewModels/MainViewModel.cs
@@ -1224,7 +1224,7 @@ namespace PEBakery.Core.ViewModels
                         // Guard instance ownership exception using Application.Current.Dispatcher.Invoke()
                         Application.Current?.Dispatcher.Invoke(() =>
                         {
-                            using (MemoryStream ms = EncodedFile.ExtractLogo(sc, out ImageHelper.ImageFormat type))
+                            using (MemoryStream ms = EncodedFile.ExtractLogo(sc, out ImageHelper.ImageFormat type, out _))
                             {
                                 switch (type)
                                 {

--- a/PEBakery/WPF/LogExportDialog.xaml
+++ b/PEBakery/WPF/LogExportDialog.xaml
@@ -134,7 +134,7 @@
                               SelectedIndex="{Binding SelectedBuildEntryIndex}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Item1}"/>
+                                <TextBlock Text="{Binding Text}"/>
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>

--- a/PEBakery/WPF/LogExportDialog.xaml.cs
+++ b/PEBakery/WPF/LogExportDialog.xaml.cs
@@ -102,7 +102,7 @@ namespace PEBakery.WPF
             {
                 // Local time should be ok because the filename is likely only useful to the person exporting the log
                 DateTime localTime = DateTime.Now;
-                dialog.FileName = $"SystemLog_{localTime.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture)}";
+                dialog.FileName = $"SystemLog_{localTime.ToString("yyyy_MM_dd_HHmmss", CultureInfo.InvariantCulture)}";
             }
             else if (_m.ExportBuildLog)
             {
@@ -112,15 +112,22 @@ namespace PEBakery.WPF
                 // Filter invalid filename chars
                 List<char> filteredChars = new List<char>(bi.Name.Length);
                 List<char> invalidChars = Path.GetInvalidFileNameChars().ToList();
-                invalidChars.Add('['); // Remove [ and ], too
+                invalidChars.Add('['); // Remove [ and ]
                 invalidChars.Add(']');
+                invalidChars.Add(' '); // Spaces are not very script or web friendly, let's remove them too.
                 foreach (char ch in bi.Name)
                 {
-                    if (!invalidChars.Contains(ch))
+                    if (invalidChars.Contains(ch))
+                    {
+                        filteredChars.Add(Convert.ToChar("_")); // Replace invalid chars and spaces with an underscore
+                    }
+                    else
+                    {
                         filteredChars.Add(ch);
+                    }
                 }
                 string filteredName = new string(filteredChars.ToArray());
-                dialog.FileName = $"BuildLog_{bi.StartTime.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture)}_{filteredName}";
+                dialog.FileName = $"BuildLog_{bi.StartTime.ToString("yyyy_MM_dd_HHmmss", CultureInfo.InvariantCulture)}_{filteredName}";
             }
 
             bool? result = dialog.ShowDialog();

--- a/PEBakery/WPF/LogExportDialog.xaml.cs
+++ b/PEBakery/WPF/LogExportDialog.xaml.cs
@@ -31,7 +31,6 @@ using PEBakery.Helper;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -81,7 +80,7 @@ namespace PEBakery.WPF
         {
             Microsoft.Win32.SaveFileDialog dialog = new Microsoft.Win32.SaveFileDialog
             {
-                Title = "Choose Destination Path",
+                Title = "Save Log As",
             };
 
             switch (_m.FileFormat)
@@ -95,6 +94,18 @@ namespace PEBakery.WPF
                 default:
                     Debug.Assert(false, "Internal Logic Error at LogExportWindow.ExportCommand_Executed");
                     break;
+            }
+
+            if (_m.ExportSystemLog)
+            {
+                DateTime localDate = DateTime.Now; // local time should be ok because the filename is likley only useful to the person exporting the log
+                dialog.FileName = $"System Log - {localDate.ToString("yyyy-MM-dd HHmmss", CultureInfo.InvariantCulture)}";
+            }
+            else if (_m.ExportBuildLog)
+            {
+                // TODO format default filename as "Build Log - <BuildInfo.StartTime (yyyy-MM-dd HHmmss)> <BuildInfo.Name>"
+                // Don't forget to remove any illegal chars \/:*?"<>| from <BuildInfo.Name> 
+                //dialog.FileName = "Build Log - ";
             }
 
             bool? result = dialog.ShowDialog();

--- a/PEBakery/WPF/LogWindow.xaml
+++ b/PEBakery/WPF/LogWindow.xaml
@@ -187,7 +187,7 @@
                                   ItemsSource="{Binding BuildEntries}">
                              <ComboBox.ItemTemplate>
                                 <DataTemplate>
-                                    <TextBlock Text="{Binding Item1}"/>
+                                    <TextBlock Text="{Binding Text}"/>
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>

--- a/PEBakery/WPF/LogWindow.xaml.cs
+++ b/PEBakery/WPF/LogWindow.xaml.cs
@@ -110,7 +110,7 @@ namespace PEBakery.WPF
         {
             if (_m.BuildEntries != null &&
                 _m.SelectedBuildIndex < _m.BuildEntries.Count &&
-                _m.BuildEntries[_m.SelectedBuildIndex].Item2 == e.Log.BuildId &&
+                _m.BuildEntries[_m.SelectedBuildIndex].Id == e.Log.BuildId &&
                 _m.ScriptEntries != null &&
                 _m.SelectedScriptIndex < _m.ScriptEntries.Count &&
                 _m.ScriptEntries[_m.SelectedScriptIndex].Item2 == e.Log.ScriptId)
@@ -144,7 +144,7 @@ namespace PEBakery.WPF
         {
             if (_m.BuildEntries != null &&
                 0 <= _m.SelectedBuildIndex && _m.SelectedBuildIndex < _m.BuildEntries.Count &&
-                _m.BuildEntries[_m.SelectedBuildIndex].Item2 == e.Log.BuildId)
+                _m.BuildEntries[_m.SelectedBuildIndex].Id == e.Log.BuildId)
             {
                 if (e.Log.Type != VarsType.Local)
                 {
@@ -422,7 +422,7 @@ namespace PEBakery.WPF
 
             // Set ObservableCollection
             SystemLogs = new ObservableCollection<LogModel.SystemLog>();
-            BuildEntries = new ObservableCollection<Tuple<string, int>>();
+            BuildEntries = new ObservableCollection<LogModel.BuildInfo>();
             ScriptEntries = new ObservableCollection<Tuple<string, int, int>>();
             LogStats = new ObservableCollection<Tuple<LogState, int>>();
             BuildLogs = new ObservableCollection<LogModel.BuildLog>();
@@ -464,9 +464,7 @@ namespace PEBakery.WPF
                 LogModel.BuildInfo[] buildEntries = LogDb.Table<LogModel.BuildInfo>()
                     .OrderByDescending(x => x.StartTime)
                     .ToArray();
-                BuildEntries = new ObservableCollection<Tuple<string, int>>(
-                    buildEntries.Select(x => new Tuple<string, int>(x.Text, x.Id))
-                );
+                BuildEntries = new ObservableCollection<LogModel.BuildInfo>(buildEntries);
             });
 
             SelectedBuildIndex = 0;
@@ -668,7 +666,7 @@ namespace PEBakery.WPF
 
                 if (0 <= value && 0 < _buildEntries.Count)
                 {
-                    int buildId = _buildEntries[value].Item2;
+                    int buildId = _buildEntries[value].Id;
                     RefreshScripts(buildId, false);
                 }
                 else
@@ -680,10 +678,10 @@ namespace PEBakery.WPF
             }
         }
 
-        // Build Name, Build Id
+        // Time, Build Name, Build Id 
         private readonly object _buildEntriesLock = new object();
-        private ObservableCollection<Tuple<string, int>> _buildEntries;
-        public ObservableCollection<Tuple<string, int>> BuildEntries
+        private ObservableCollection<LogModel.BuildInfo> _buildEntries;
+        public ObservableCollection<LogModel.BuildInfo> BuildEntries
         {
             get => _buildEntries;
             set => SetCollectionProperty(ref _buildEntries, _buildEntriesLock, value);

--- a/PEBakery/WPF/ScriptEditWindow.xaml.cs
+++ b/PEBakery/WPF/ScriptEditWindow.xaml.cs
@@ -1929,12 +1929,13 @@ namespace PEBakery.WPF
                     return;
                 }
 
-                using (MemoryStream ms = EncodedFile.ExtractLogo(Script, out ImageHelper.ImageFormat type))
+                using (MemoryStream ms = EncodedFile.ExtractLogo(Script, out ImageHelper.ImageFormat type, out string filename))
                 {
                     SaveFileDialog dialog = new SaveFileDialog
                     {
                         InitialDirectory = Global.BaseDir,
                         OverwritePrompt = true,
+                        FileName = filename,
                         Filter = $"{type.ToString().ToUpper().Replace(".", String.Empty)} Image|*.{type}",
                         DefaultExt = $".{type}",
                         AddExtension = true,
@@ -2883,6 +2884,7 @@ namespace PEBakery.WPF
                 SaveFileDialog dialog = new SaveFileDialog
                 {
                     OverwritePrompt = true,
+                    FileName = fileName,
                     Filter = extFilter,
                     DefaultExt = ext,
                     AddExtension = true,
@@ -3389,6 +3391,7 @@ namespace PEBakery.WPF
                 SaveFileDialog dialog = new SaveFileDialog
                 {
                     OverwritePrompt = true,
+                    FileName = info.FileName,
                     Filter = $"{ext.ToUpper().Replace(".", string.Empty)} File|*{ext}"
                 };
 
@@ -3528,7 +3531,7 @@ namespace PEBakery.WPF
                     return;
                 }
 
-                using (MemoryStream ms = EncodedFile.ExtractLogo(Script, out ImageHelper.ImageFormat type))
+                using (MemoryStream ms = EncodedFile.ExtractLogo(Script, out ImageHelper.ImageFormat type, out _))
                 {
                     switch (type)
                     {


### PR DESCRIPTION
Working on adding default filenames as a user convenience for SaveAs operations.
- Manually extracted (logo/image/attachment) files default to original encoded filename
- System Log defaults to `System Log - yyyy-MM-dd HHmmss` eg. *System Log - 2019-02-19 140305.txt*
- **TODO:** Build Log default to `Build Log - <BuildInfo.StartTime (yyyy-MM-dd HHmmss)> <BuildInfo.Name>` eg. *Build Log - 2019-02-19 140305 myProject.txt*

 but I'm not sure the best way to get the StartTime and Name of the selected build log.