### PR TITLE
Interace Editor Select Issue Fix

### DIFF
--- a/PEBakery/WPF/Controls/DragCanvas.cs
+++ b/PEBakery/WPF/Controls/DragCanvas.cs
@@ -199,27 +199,28 @@ namespace PEBakery.WPF.Controls
                             { // Nothing is selected, and new control was clicked (-> SingleMove)
                                 _dragMode = DragMode.SingleMove;
                                 AddSelectedElements(selected);
-                                goto default;
-                            }
-                           
-                            bool alreadySelected = _selectedElements.Any(x => x.UIControl.Key.Equals(selected.UIControl.Key, StringComparison.OrdinalIgnoreCase));
-                            if (alreadySelected)
-                            {  // The clicked control is already selected (-> SingleMove, MultiMove)
-                                if (_selectedElements.Count == 1)
-                                    _dragMode = DragMode.SingleMove;
-                                else
-                                    _dragMode = DragMode.MultiMove;
-                            }
-                            else if (multiClick)
-                            { // Add clicked control to selected list (-> MultiMove)
-                                _dragMode = DragMode.MultiMove;
-                                AddSelectedElements(selected);
                             }
                             else
-                            { // Change selected control to clicked one (-> SingleMove)
-                                _dragMode = DragMode.SingleMove;
-                                ClearSelectedElements(true);
-                                AddSelectedElements(selected);
+                            {
+                                bool alreadySelected = _selectedElements.Any(x => x.UIControl.Key.Equals(selected.UIControl.Key, StringComparison.OrdinalIgnoreCase));
+                                if (alreadySelected)
+                                {  // The clicked control is already selected (-> SingleMove, MultiMove)
+                                    if (_selectedElements.Count == 1)
+                                        _dragMode = DragMode.SingleMove;
+                                    else
+                                        _dragMode = DragMode.MultiMove;
+                                }
+                                else if (multiClick)
+                                { // Add clicked control to selected list (-> MultiMove)
+                                    _dragMode = DragMode.MultiMove;
+                                    AddSelectedElements(selected);
+                                }
+                                else
+                                { // Change selected control to clicked one (-> SingleMove)
+                                    _dragMode = DragMode.SingleMove;
+                                    ClearSelectedElements(true);
+                                    AddSelectedElements(selected);
+                                }
                             }
                         }
                         break;

--- a/PEBakery/WPF/Controls/DragCanvas.cs
+++ b/PEBakery/WPF/Controls/DragCanvas.cs
@@ -193,14 +193,34 @@ namespace PEBakery.WPF.Controls
                 switch (_dragMode)
                 {
                     case DragMode.None:
-                        { // St to SingleMove
-                            _dragMode = DragMode.SingleMove;
+                        {
                             SelectedElement selected = new SelectedElement(focusedElement);
-                            // TODO: 한 번 클릭한 다음 다시 클릭하면 꼭 여기서 걸린다
-                            // -> _selectedElements 처리에 문제가 있다
-                            // 하나만 클릭하고 드래그하는건데, 2개로 카운트되어 있다 (같은게 2번 체크됨)
-                            Debug.Assert(_selectedElements.Count == 0);
-                            AddSelectedElements(selected);
+                            if (_selectedElements.Count == 0)
+                            { // Nothing is selected, and new control was clicked (-> SingleMove)
+                                _dragMode = DragMode.SingleMove;
+                                AddSelectedElements(selected);
+                                goto default;
+                            }
+                           
+                            bool alreadySelected = _selectedElements.Any(x => x.UIControl.Key.Equals(selected.UIControl.Key, StringComparison.OrdinalIgnoreCase));
+                            if (alreadySelected)
+                            {  // The clicked control is already selected (-> SingleMove, MultiMove)
+                                if (_selectedElements.Count == 1)
+                                    _dragMode = DragMode.SingleMove;
+                                else
+                                    _dragMode = DragMode.MultiMove;
+                            }
+                            else if (multiClick)
+                            { // Add clicked control to selected list (-> MultiMove)
+                                _dragMode = DragMode.MultiMove;
+                                AddSelectedElements(selected);
+                            }
+                            else
+                            { // Change selected control to clicked one (-> SingleMove)
+                                _dragMode = DragMode.SingleMove;
+                                ClearSelectedElements(true);
+                                AddSelectedElements(selected);
+                            }
                         }
                         break;
                     case DragMode.SingleMove:
@@ -225,6 +245,8 @@ namespace PEBakery.WPF.Controls
                                 AddSelectedElements(selected);
                             }
                         }
+                        break;
+                    default:
                         break;
                 }
 
@@ -305,8 +327,8 @@ namespace PEBakery.WPF.Controls
                 case DragMode.MultiMove:
                     {
                         Debug.Assert(0 < _selectedElements.Count, "Incorrect SelectedElement handling");
-                        Rect[] elementRectList = _selectedElements.Select(se => se.ElementInitialRect).ToArray();
-                        (List<Point> newPosList, Vector delta) = CalcNewPositions(_dragStartCursorPos, nowCursorPos, elementRectList);
+                        Rect[] elementRects = _selectedElements.Select(se => se.ElementInitialRect).ToArray();
+                        (List<Point> newPosList, Vector delta) = CalcNewPositions(_dragStartCursorPos, nowCursorPos, elementRects);
 
                         for (int i = 0; i < _selectedElements.Count; i++)
                         {
@@ -443,6 +465,8 @@ namespace PEBakery.WPF.Controls
                         uiCtrl.Width = (int)newCtrlRect.Width;
                         uiCtrl.Height = (int)newCtrlRect.Height;
 
+                        _dragMode = DragMode.None;
+
                         UIControlResized?.Invoke(this, new UIControlDraggedEventArgs(uiCtrl, _dragStartCursorPos, delta, false, DragState.Finished));
                     }
                     break;
@@ -466,6 +490,8 @@ namespace PEBakery.WPF.Controls
                             uiCtrl.Height = (int)newCtrlRect.Height;
                         }
 
+                        _dragMode = DragMode.None;
+
                         UIControlResized?.Invoke(this, new UIControlDraggedEventArgs(uiCtrls, _dragStartCursorPos, delta, false, DragState.Finished));
                     }
                     break;
@@ -477,7 +503,7 @@ namespace PEBakery.WPF.Controls
         }
         #endregion
 
-        #region (public) SelectedElements
+        #region (public) SelectedElementsAddSelectedElements
         /// <summary>
         /// Clear border and drag handles around selected element
         /// </summary>

--- a/PEBakery/WPF/ScriptEditWindow.xaml
+++ b/PEBakery/WPF/ScriptEditWindow.xaml
@@ -525,56 +525,64 @@
                                             <RowDefinition Height="20" />
                                             <RowDefinition Height="20" />
                                             <RowDefinition Height="20" />
+                                            <RowDefinition Height="20" />
                                         </Grid.RowDefinitions>
 
                                         <!-- General Properties -->
                                         <TextBlock Grid.Row="0" Grid.Column="0"
                                                    Margin="0, 0, 5, 0"
+                                                   Text="Type" />
+                                        <TextBox Grid.Row="0" Grid.Column="1"
+                                                 IsReadOnly="True"
+                                                 IsEnabled="{Binding UICtrlEditEnabled}"
+                                                 Text="{Binding UICtrlType, Mode=OneWay}" />
+                                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                                   Margin="0, 0, 5, 0"
                                                    Text="Visible" />
-                                        <CheckBox Grid.Row="0" Grid.Column="1"
+                                        <CheckBox Grid.Row="1" Grid.Column="1"
                                                   VerticalContentAlignment="Center"
                                                   IsEnabled="{Binding UICtrlEditEnabled}"
                                                   IsChecked="{Binding UICtrlVisible}"/>
-                                        <TextBlock Grid.Row="1" Grid.Column="0"
-                                                   Margin="0, 0, 5, 0"
-                                                   Text="X" />
-                                        <ccc:NumberBox Grid.Row="1" Grid.Column="1"
-                                                          VerticalContentAlignment="Center"
-                                                          FontSize="11"
-                                                          Minimum="0"
-                                                          IsEnabled="{Binding UICtrlEditEnabled}"
-                                                          Value="{Binding UICtrlX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                                         <TextBlock Grid.Row="2" Grid.Column="0"
                                                    Margin="0, 0, 5, 0"
-                                                   Text="Y"/>
+                                                   Text="X" />
                                         <ccc:NumberBox Grid.Row="2" Grid.Column="1"
                                                           VerticalContentAlignment="Center"
                                                           FontSize="11"
                                                           Minimum="0"
                                                           IsEnabled="{Binding UICtrlEditEnabled}"
-                                                          Value="{Binding UICtrlY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                                          Value="{Binding UICtrlX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                                         <TextBlock Grid.Row="3" Grid.Column="0"
                                                    Margin="0, 0, 5, 0"
-                                                   Text="Width"/>
+                                                   Text="Y"/>
                                         <ccc:NumberBox Grid.Row="3" Grid.Column="1"
                                                           VerticalContentAlignment="Center"
                                                           FontSize="11"
                                                           Minimum="0"
                                                           IsEnabled="{Binding UICtrlEditEnabled}"
-                                                          Value="{Binding UICtrlWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                                          Value="{Binding UICtrlY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                                         <TextBlock Grid.Row="4" Grid.Column="0"
                                                    Margin="0, 0, 5, 0"
-                                                   Text="Height" />
+                                                   Text="Width"/>
                                         <ccc:NumberBox Grid.Row="4" Grid.Column="1"
                                                           VerticalContentAlignment="Center"
                                                           FontSize="11"
                                                           Minimum="0"
                                                           IsEnabled="{Binding UICtrlEditEnabled}"
-                                                          Value="{Binding UICtrlHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                                          Value="{Binding UICtrlWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                                         <TextBlock Grid.Row="5" Grid.Column="0"
                                                    Margin="0, 0, 5, 0"
+                                                   Text="Height" />
+                                        <ccc:NumberBox Grid.Row="5" Grid.Column="1"
+                                                          VerticalContentAlignment="Center"
+                                                          FontSize="11"
+                                                          Minimum="0"
+                                                          IsEnabled="{Binding UICtrlEditEnabled}"
+                                                          Value="{Binding UICtrlHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                        <TextBlock Grid.Row="6" Grid.Column="0"
+                                                   Margin="0, 0, 5, 0"
                                                    Text="ToolTip" />
-                                        <TextBox Grid.Row="5" Grid.Column="1"
+                                        <TextBox Grid.Row="6" Grid.Column="1"
                                                  VerticalContentAlignment="Center"
                                                  FontSize="11"
                                                  IsEnabled="{Binding UICtrlEditEnabled}"
@@ -1089,79 +1097,11 @@
                                                  Text="{Binding UICtrlText, Converter={StaticResource StringEscapeConverter}, UpdateSourceTrigger=PropertyChanged}"/>
                                     </Grid>
                                     <!-- Common - ListItemBox -->
-                                    <Button Height="20"  Margin="0, 10, 0, 0"
-                                            Visibility="{Binding ShowUICtrlListItemButton}" 
+                                    <Button Height="25"
+                                            Margin="0, 10, 0, 0"
+                                            Visibility="{Binding ShowUICtrlListItemButton}"
                                             Command="{Binding UICtrlListItemEditCommand}"
-                                            Content="{Binding UICtrlListItemEditButtonText, Mode=OneWay}"/>
-                                    <!--
-                                    <Grid Visibility="{Binding ShowUICtrlListItemBox}" Margin="0, 10, 0, 0">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition />
-                                            <ColumnDefinition Width="25" />
-                                        </Grid.ColumnDefinitions>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="20" />
-                                            <RowDefinition Height="25" />
-                                            <RowDefinition Height="25" />
-                                            <RowDefinition Height="25" />
-                                            <RowDefinition Height="25" />
-                                            <RowDefinition Height="25" />
-                                        </Grid.RowDefinitions>
-                                        <TextBlock Grid.Row="0" Grid.Column="0"
-                                                   Grid.ColumnSpan="2"
-                                                   Text="Items"/>
-                                        <ListBox Grid.Row="1" Grid.Column="0"
-                                                 Grid.RowSpan="4"
-                                                 SelectedIndex="{Binding UICtrlListItemBoxSelectedIndex}"
-                                                 ItemsSource="{Binding UICtrlListItemBoxItems}"/>
-                                        <TextBox Grid.Row="5" Grid.Column="0"
-                                                 VerticalContentAlignment="Center"
-                                                 PreviewTextInput="ListNewItem_PreviewTextInput"
-                                                 Text="{Binding UICtrlListItemBoxNewItem, Converter={StaticResource StringEscapeConverter}}"/>
-                                        <Button Grid.Row="1" Grid.Column="1"
-                                                x:Name="UICtrlListItemBoxUp"
-                                                Command="{Binding UICtrlListItemBoxUpCommand}"
-                                              ToolTip="Up">
-                                            <iconPacks:PackIconMaterial Kind="ChevronUp"
-                                                                        Width="Auto"
-                                                                        Height="Auto"
-                                                                        Margin="3"/>
-                                        </Button>
-                                        <Button Grid.Row="2" Grid.Column="1"
-                                                x:Name="UICtrlListItemBoxDown"
-                                                Command="{Binding UICtrlListItemBoxDownCommand}"
-                                                ToolTip="Down">
-                                            <iconPacks:PackIconMaterial Kind="ChevronDown"
-                                                                        Width="Auto"
-                                                                        Height="Auto"
-                                                                        Margin="3"/>
-                                        </Button>
-                                        <Button Grid.Row="3" Grid.Column="1"
-                                                x:Name="UICtrlListItemBoxSelect"
-                                                Command="{Binding UICtrlListItemBoxSelectCommand}"
-                                                ToolTip="Select" >
-                                            <TextBlock Text="S" FontWeight="Bold"/>
-                                        </Button>
-                                        <Button Grid.Row="4" Grid.Column="1"
-                                                x:Name="UICtrlListItemBoxDelete"
-                                                Command="{Binding UICtrlListItemBoxDeleteCommand}"
-                                                ToolTip="Delete">
-                                            <iconPacks:PackIconMaterial Kind="Minus" 
-                                                                        Width="Auto"
-                                                                        Height="Auto"
-                                                                        Margin="3"/>
-                                        </Button>
-                                        <Button Grid.Row="5" Grid.Column="1"
-                                                x:Name="UICtrlListItemBoxAdd"
-                                                Command="{Binding UICtrlListItemBoxAddCommand}"
-                                                ToolTip="Add">
-                                            <iconPacks:PackIconMaterial Kind="Plus" 
-                                                                        Width="Auto"
-                                                                        Height="Auto"
-                                                                        Margin="3"/>
-                                        </Button>
-                                    </Grid>
-                                    -->
+                                            Content="{Binding UICtrlListItemEditButtonText, Mode=OneWay}" />
                                     <!-- Common - RunOptional-->
                                     <TextBlock Visibility="{Binding ShowUICtrlRunOptional}"
                                                Text="Optional Engine Run"

--- a/PEBakery/WPF/ScriptEditWindow.xaml.cs
+++ b/PEBakery/WPF/ScriptEditWindow.xaml.cs
@@ -308,7 +308,7 @@ namespace PEBakery.WPF
                     break;
                 case DragState.Finished:
                     { // Dragging finished, refresh dragged UIControl
-                        if (!e.MultiSelect)
+                        if (e.MultiSelect == false)
                         {
                             // m.SelectedUICtrl should have been set to e.UIControl by InterfaceCanvas_UIControlSelected
                             Debug.Assert(m.SelectedUICtrl == e.UIControl, "Incorrect m.SelectedUICtrl");

--- a/PEBakery/WPF/ScriptEditWindow.xaml.cs
+++ b/PEBakery/WPF/ScriptEditWindow.xaml.cs
@@ -1067,6 +1067,7 @@ namespace PEBakery.WPF
 
                 // UIControl Shared Argument
                 OnPropertyUpdate(nameof(UICtrlEditEnabled));
+                OnPropertyUpdate(nameof(UICtrlType));
                 OnPropertyUpdate(nameof(UICtrlKey));
                 OnPropertyUpdate(nameof(UICtrlText));
                 OnPropertyUpdate(nameof(UICtrlVisible));
@@ -1108,6 +1109,7 @@ namespace PEBakery.WPF
 
                 // UIControl Shared Argument
                 OnPropertyUpdate(nameof(UICtrlEditEnabled));
+                OnPropertyUpdate(nameof(UICtrlType));
                 OnPropertyUpdate(nameof(UICtrlKey));
                 OnPropertyUpdate(nameof(UICtrlText));
                 OnPropertyUpdate(nameof(UICtrlVisible));
@@ -1140,6 +1142,10 @@ namespace PEBakery.WPF
 
         #region Shared Arguments
         public bool UICtrlEditEnabled => _selectedUICtrl != null;
+        public string UICtrlType
+        {
+            get => _selectedUICtrl != null ? _selectedUICtrl.Type.ToString() : "None";
+        }
         public string UICtrlKey
         {
             get => _selectedUICtrl != null ? _selectedUICtrl.Key : string.Empty;
@@ -2559,7 +2565,10 @@ namespace PEBakery.WPF
                 };
                 bool? result = editWindow.ShowDialog();
                 if (result == true)
+                {
+                    UICtrlListItemCount = UICtrlComboBoxInfo.Items.Count;
                     InvokeUIControlEvent(false);
+                }
             }
             finally
             {


### PR DESCRIPTION
## Summary

- This PR fixes interface editor select issue, resolves #155.
- Minor adjustments like UIControl type indicator.

## Details

- `DragCanvas`'s `DragMode` state machine have been broken in `OnPreviewMouseLeftButtonDown()`.
This PR redesigns `DragMode.None` -> `DragMode.SingleMove/MultiMove` state change.