### PR TITLE
Add Filter= to FileBox control

### DIFF
--- a/PEBakery.Core.Tests/StringEscaperTests.cs
+++ b/PEBakery.Core.Tests/StringEscaperTests.cs
@@ -666,7 +666,7 @@ namespace PEBakery.Core.Tests
         [TestMethod]
         public void IsFileNameValid()
         {
-            void Template(string path, bool result, IEnumerable<char> more = null)
+            static void Template(string path, bool result, IEnumerable<char> more = null)
             {
                 Assert.IsTrue(StringEscaper.IsFileNameValid(path, more) == result);
             }
@@ -686,6 +686,28 @@ namespace PEBakery.Core.Tests
             Template(@"A[BC", false, new char[] { '[' });
             Template(@"\A[BC", false, new char[] { '[' });
             Template(@"A:\A[BC", false, new char[] { '[' });
+        }
+        #endregion
+
+        #region IsFileFilterValid
+        [TestMethod]
+        public void IsFileFilterValid()
+        {
+            static void Template(string filter, bool result)
+            {
+                Assert.IsTrue(StringEscaper.IsFileFilterValid(filter) == result);
+            }
+
+            Template(@"Txt Files|*.txt;*.log|All Files|*.*", true);
+            Template(@"Txt Files", false);
+            Template(@"Txt Files|", false);
+            Template(@"Office Files|*.doc;*.xls*.ppt", true);
+            Template(@"Office Files|*.doc;*.xls;*.ppt;", true);
+            Template(@"Office Files|*.doc;*.xls;*.ppt;;;;;dummy", true);
+            Template(@"Word Documents|*.doc|Excel Worksheets|*.xls|PowerPoint Presentations|*.ppt", true);
+            Template(@"Word Documents|*.doc|Excel Worksheets|filename", true);
+            Template(@"Word Documents|*.doc|Excel Worksheets", false);
+            Template(@"Word Documents|*.doc|Excel Worksheets|", false);
         }
         #endregion
 

--- a/PEBakery.Core/StringEscaper.cs
+++ b/PEBakery.Core/StringEscaper.cs
@@ -171,6 +171,23 @@ namespace PEBakery.Core
         {
             return Uri.TryCreate(url, UriKind.Absolute, out _);
         }
+
+        /// <summary>
+        /// Check if given filter is a valid Microsoft.Win32.OpenFileDialog.Filter format.
+        /// </summary>
+        /// <param name="filter">File filter string to test</param>
+        /// <returns>True if valid</returns>
+        public static bool IsFileFilterValid(string filter)
+        {
+            // https://docs.microsoft.com/ko-kr/dotnet/api/microsoft.win32.filedialog.filter?view=windowsdesktop-6.0
+            // Ex) Valid -> Txt Files|*.txt;*.log|All Files|*.*
+            //   Invalid -> Txt Files
+
+            // Valid format = [<DisplayText>|<wildcard1>;<wildcard2>;...] | [<DisplayText>|<wildcard1>;<wildcard2>;...]
+            //                           Txt Files     | *.txt;*.log   | All Files   | *.*
+            const string filterRegex = @"^([^\|\r\n]+)\|([^\|\r\n]+)+(\|([^\|\r\n]+)\|([^\|\r\n]+))*$";
+            return Regex.IsMatch(filter, filterRegex, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        }
         #endregion
 
         #region EscapeString

--- a/PEBakery.Core/SyntaxChecker.cs
+++ b/PEBakery.Core/SyntaxChecker.cs
@@ -465,6 +465,17 @@ namespace PEBakery.Core
                             }
                         }
                         break;
+                    case UIControlType.FileBox:
+                        {
+                            UIInfo_FileBox info = uiCtrl.Info.Cast<UIInfo_FileBox>();
+
+                            if (info.Filter != null)
+                            {
+                                if (StringEscaper.IsFileFilterValid(info.Filter) == false)
+                                    logs.Add(new LogInfo(LogState.Error, $"File filter pattern [{info.Filter}] is invalid", uiCtrl));
+                            }
+                        }
+                        break;
                     case UIControlType.RadioGroup:
                         {
                             UIInfo_RadioGroup info = uiCtrl.Info.Cast<UIInfo_RadioGroup>();

--- a/PEBakery.Core/SyntaxChecker.cs
+++ b/PEBakery.Core/SyntaxChecker.cs
@@ -469,11 +469,19 @@ namespace PEBakery.Core
                         {
                             UIInfo_FileBox info = uiCtrl.Info.Cast<UIInfo_FileBox>();
 
-                            if (info.Filter != null)
-                            {
-                                string filter = StringEscaper.Unescape(info.Filter);
-                                if (StringEscaper.IsFileFilterValid(filter) == false)
-                                    logs.Add(new LogInfo(LogState.Error, $"File filter pattern [{filter}] is invalid", uiCtrl));
+                            if (info.IsFile)
+                            { // Select File
+                                if (info.Filter != null)
+                                {
+                                    string filter = StringEscaper.Unescape(info.Filter);
+                                    if (StringEscaper.IsFileFilterValid(filter) == false)
+                                        logs.Add(new LogInfo(LogState.Error, $"File filter pattern [{filter}] is invalid", uiCtrl));
+                                }
+                            }
+                            else
+                            { // Select Folder
+                                if (info.Filter != null)
+                                    logs.Add(new LogInfo(LogState.Warning, $"File filter not supported on folder selection", uiCtrl));
                             }
                         }
                         break;

--- a/PEBakery.Core/SyntaxChecker.cs
+++ b/PEBakery.Core/SyntaxChecker.cs
@@ -471,8 +471,9 @@ namespace PEBakery.Core
 
                             if (info.Filter != null)
                             {
-                                if (StringEscaper.IsFileFilterValid(info.Filter) == false)
-                                    logs.Add(new LogInfo(LogState.Error, $"File filter pattern [{info.Filter}] is invalid", uiCtrl));
+                                string filter = StringEscaper.Unescape(info.Filter);
+                                if (StringEscaper.IsFileFilterValid(filter) == false)
+                                    logs.Add(new LogInfo(LogState.Error, $"File filter pattern [{filter}] is invalid", uiCtrl));
                             }
                         }
                         break;

--- a/PEBakery.Core/UIControl.cs
+++ b/PEBakery.Core/UIControl.cs
@@ -122,7 +122,7 @@ namespace PEBakery.Core
                      [FontSize]   : Default 8 (Added in PEBakery) 
                      [FontWeight] : Normal, Bold (Added in PEBakery) 
                      [FontStyle]  : Italic, Underline, Strike (Added in PEBakery) 
-    13 FileBox     = [file|dir][Title=<StringValue>]
+    13 FileBox     = [file|dir][Title=<StringValue>][Filter=<StringValue>]
     14 RadioGroup  = <StringValue1>,<StringValue2>, ... ,<StringValueN>,<IntegerIndex>  +[RunOptional]
                      // IntegerIndex : selected index, starting from 0
 
@@ -1070,12 +1070,14 @@ namespace PEBakery.Core
         public bool IsFile { get; set; }
         // Optional
         public string Title { get; set; }
+        public string Filter { get; set; }
 
-        public UIInfo_FileBox(string tooltip, bool isFile, string title)
+        public UIInfo_FileBox(string tooltip, bool isFile, string title, string filter)
             : base(tooltip)
         {
             IsFile = isFile;
             Title = title;
+            Filter = filter;
         }
 
         public override string ForgeRawLine()
@@ -1086,6 +1088,11 @@ namespace PEBakery.Core
             {
                 b.Append(',');
                 b.Append(StringEscaper.DoubleQuote($"Title={Title}"));
+            }
+            if (IsFile && Filter != null)
+            {
+                b.Append(',');
+                b.Append(StringEscaper.DoubleQuote($"Filter={Filter}"));
             }
             b.Append(ForgeToolTip());
             return b.ToString();

--- a/PEBakery.Core/UIParser.cs
+++ b/PEBakery.Core/UIParser.cs
@@ -551,7 +551,7 @@ namespace PEBakery.Core
                 case UIControlType.FileBox:
                     {
                         const int minOpCount = 0;
-                        const int maxOpCount = 2;
+                        const int maxOpCount = 3;
                         if (CodeParser.CheckInfoArgumentCount(args, minOpCount, maxOpCount + 1))
                             throw new InvalidCommandException($"[{type}] can have [{minOpCount}] ~ [{maxOpCount + 1}] arguments");
 
@@ -565,17 +565,29 @@ namespace PEBakery.Core
                         }
 
                         string title = null;
+                        string filter = null;
                         string tooltip = null;
+
+                        const string titleKey = "Title=";
+                        const string filterKey = "Filter=";
+
                         for (int i = 1; i < args.Count; i++)
                         {
                             string arg = args[i];
 
-                            const string splitKey = "Title=";
-                            if (arg.StartsWith(splitKey, StringComparison.OrdinalIgnoreCase))
+                            if (arg.StartsWith(titleKey, StringComparison.OrdinalIgnoreCase))
                             {
                                 if (title != null)
                                     throw new InvalidCommandException("Argument <Title> cannot be duplicated");
-                                title = arg.Substring(splitKey.Length);
+                                title = arg.Substring(titleKey.Length);
+                            }
+                            else if (arg.StartsWith(filterKey, StringComparison.OrdinalIgnoreCase))
+                            {
+                                if (!isFile)
+                                    throw new InvalidCommandException("Argument <Filter> can only be used for file selection");
+                                if (filter != null)
+                                    throw new InvalidCommandException("Argument <Filter> cannot be duplicated");
+                                filter = arg.Substring(filterKey.Length);
                             }
                             else if (arg.StartsWith("__", StringComparison.OrdinalIgnoreCase)) // ToolTip
                             {
@@ -587,7 +599,7 @@ namespace PEBakery.Core
                             }
                         }
 
-                        return new UIInfo_FileBox(tooltip, isFile, title);
+                        return new UIInfo_FileBox(tooltip, isFile, title, filter);
                     }
                 #endregion
                 #region RadioGroup

--- a/PEBakery.Core/UIRenderer.cs
+++ b/PEBakery.Core/UIRenderer.cs
@@ -1352,8 +1352,8 @@ namespace PEBakery.Core
                 if (info.Filter != null)
                 {
                     // info.Filter is independently validated at SyntaxChecker.
-                    // Let UIControl displayed even at worst case, so do not call StringEscaper.IsFileFilterValid() here.
-                    filter = info.Filter;
+                    // Let UIControl be displayed even at worst case, so do not call StringEscaper.IsFileFilterValid() here.
+                    filter = StringEscaper.Unescape(info.Filter);
                 }
 
                 Microsoft.Win32.OpenFileDialog dialog = new Microsoft.Win32.OpenFileDialog
@@ -1385,7 +1385,8 @@ namespace PEBakery.Core
             else
             { // Directory
                 // .Net Core's System.Windows.Forms.FolderBrowserDialog (WinForms) does support Vista-style dialog.
-                // But it requires HWND to be displayed properly.
+                // But it requires HWND to be displayed properly, which UIRenderer does not have.
+                // Use Ookii's VistaFolderBrowserDialog instead.
                 VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog();
 
                 string currentPath = StringEscaper.Preprocess(_variables, uiCtrl.Text);

--- a/PEBakery.Core/UIRenderer.cs
+++ b/PEBakery.Core/UIRenderer.cs
@@ -1347,15 +1347,28 @@ namespace PEBakery.Core
                     currentPath = string.Empty;
                 Debug.Assert(currentPath != null);
 
+                string filter = "All Files|*.*";
+                if (info.Filter != null)
+                {
+                    // TODO: Should we verify we have a valid Description/Filter Pattern pair or just throw the system exception and fallack to "All Files|*.*"
+                    filter = info.Filter;
+                }
+
                 Microsoft.Win32.OpenFileDialog dialog = new Microsoft.Win32.OpenFileDialog
                 {
-                    Filter = "All Files|*.*",
                     InitialDirectory = currentPath,
                 };
 
                 if (info.Title != null)
                 {
                     dialog.Title = StringEscaper.Unescape(info.Title);
+                }
+
+                try { dialog.Filter = filter; }
+                catch (ArgumentException argEx) // Invalid Filter string
+                {
+                    Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"{argEx.Message}\r\n{uiCtrl.RawLine} (Line {uiCtrl.LineIdx})"));
+                    dialog.Filter = "All Files|*.*"; // Fallback to default filter
                 }
 
                 if (dialog.ShowDialog() == true)

--- a/PEBakery/WPF/ScriptEditWindow.xaml
+++ b/PEBakery/WPF/ScriptEditWindow.xaml
@@ -62,6 +62,7 @@
         <local:ColorToSolidColorBrushConverter x:Key="ColorToSolidColorBrushConverter"/>
         <local:ActiveInterfaceSectionVisibilityConverter x:Key="ActiveInterfaceSectionVisibilityConverter"/>
         <local:StringEscapeConverter x:Key="StringEscapeConverter" />
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <Style x:Key="MultiSelectAlternativeListViewColor" BasedOn="{StaticResource AlternativeListViewColor}" TargetType="{x:Type ListViewItem}">
             <Style.Triggers>
                 <Trigger Property="ItemsControl.AlternationIndex" Value="0">
@@ -1084,9 +1085,10 @@
                                                  Text="{Binding UICtrlFileBoxTitle, Converter={StaticResource StringEscapeConverter}, UpdateSourceTrigger=PropertyChanged}"/>
                                         <TextBlock Grid.Row="4" Grid.Column="0"
                                                    Margin="0, 0, 5, 0"
-                                                   Text="Filter" />
+                                                   Text="File Filter" />
                                         <TextBox Grid.Row="4" Grid.Column="1"
                                                  VerticalContentAlignment="Center"
+                                                 IsEnabled="{Binding UICtrlFileBoxFileChecked, UpdateSourceTrigger=PropertyChanged}"
                                                  Text="{Binding UICtrlFileBoxFilter, Converter={StaticResource StringEscapeConverter}, UpdateSourceTrigger=PropertyChanged}"/>
                                     </Grid>
                                     <!-- RadioGroup -->

--- a/PEBakery/WPF/ScriptEditWindow.xaml
+++ b/PEBakery/WPF/ScriptEditWindow.xaml
@@ -1055,6 +1055,7 @@
                                             <RowDefinition Height="20" />
                                             <RowDefinition Height="20" />
                                             <RowDefinition Height="20" />
+                                            <RowDefinition Height="20" />
                                         </Grid.RowDefinitions>
                                         <TextBlock Grid.Row="0" Grid.Column="0"
                                                    Margin="0, 0, 5, 0"
@@ -1081,6 +1082,12 @@
                                         <TextBox Grid.Row="3" Grid.Column="1"
                                                  VerticalContentAlignment="Center"
                                                  Text="{Binding UICtrlFileBoxTitle, Converter={StaticResource StringEscapeConverter}, UpdateSourceTrigger=PropertyChanged}"/>
+                                        <TextBlock Grid.Row="4" Grid.Column="0"
+                                                   Margin="0, 0, 5, 0"
+                                                   Text="Filter" />
+                                        <TextBox Grid.Row="4" Grid.Column="1"
+                                                 VerticalContentAlignment="Center"
+                                                 Text="{Binding UICtrlFileBoxFilter, Converter={StaticResource StringEscapeConverter}, UpdateSourceTrigger=PropertyChanged}"/>
                                     </Grid>
                                     <!-- RadioGroup -->
                                     <Grid Visibility="{Binding IsUICtrlRadioGroup}" Margin="0, 10, 0, 0">

--- a/PEBakery/WPF/ScriptEditWindow.xaml.cs
+++ b/PEBakery/WPF/ScriptEditWindow.xaml.cs
@@ -1781,6 +1781,7 @@ namespace PEBakery.WPF
                 OnPropertyUpdate(nameof(UICtrlFileBoxFileChecked));
                 OnPropertyUpdate(nameof(UICtrlFileBoxDirChecked));
                 OnPropertyUpdate(nameof(UICtrlFileBoxTitle));
+                OnPropertyUpdate(nameof(UICtrlFileBoxFilter));
             }
         }
         public bool UICtrlFileBoxFileChecked
@@ -1822,6 +1823,19 @@ namespace PEBakery.WPF
 
                 _uiCtrlFileBoxInfo.Title = value;
                 OnPropertyUpdate(nameof(UICtrlFileBoxTitle));
+                InvokeUIControlEvent(true);
+            }
+        }
+        public string UICtrlFileBoxFilter
+        {
+            get => _uiCtrlFileBoxInfo?.Filter ?? string.Empty;
+            set
+            {
+                if (_uiCtrlFileBoxInfo == null)
+                    return;
+
+                _uiCtrlFileBoxInfo.Filter = value;
+                OnPropertyUpdate(nameof(UICtrlFileBoxFilter));
                 InvokeUIControlEvent(true);
             }
         }

--- a/PEBakery/WPF/ScriptEditWindow.xaml.cs
+++ b/PEBakery/WPF/ScriptEditWindow.xaml.cs
@@ -376,8 +376,8 @@ namespace PEBakery.WPF
             // [*] Delete UIControl
             if (e.Key == Key.Delete && e.KeyboardDevice.Modifiers == ModifierKeys.None)
             {
-                if ((m.SelectMode == ScriptEditViewModel.ControlSelectMode.SingleSelect || 
-                    m.SelectMode == ScriptEditViewModel.ControlSelectMode.MultiSelect))
+                if (m.SelectMode == ScriptEditViewModel.ControlSelectMode.SingleSelect || 
+                    m.SelectMode == ScriptEditViewModel.ControlSelectMode.MultiSelect)
                     m.UICtrlDeleteCommand.Execute(null);
                 return;
             }


### PR DESCRIPTION
This PR adds initial support for the `Filter=` option on the FileBox control and allows the script developer to define a filter for the file picker. The filter string follows the same format as the Win32.OpenFileDialog()

@ied206 The filter works well, but currently there is no error checking at parse time to ensure the user provided a valid filter string. Instead its using try/catch at runtime to detect when an invalid filter string has been supplied and logs a system exception (which I was surprised, is actually a nicely worded message!) and fallback to the default filter of `All Files|*.*`. Do you think this is acceptable behavior?

Valid Filter
`FileBox01=FileBox01,1,13,93,154,200,20,file,Title=Test,Filter=Txt Files|*.txt;*.log|All Files|*.*`

Invalid Filter
`FileBox01=FileBox01,1,13,93,154,200,20,file,Title=Test,Filter=Txt Files`

Todo:
- [ ] ScriptEditWindow
 