### PR TITLE
Disable parallel test execution on Azure Pipelines

### DIFF
--- a/PEBakery.Core.Tests/FileUpdaterTests.cs
+++ b/PEBakery.Core.Tests/FileUpdaterTests.cs
@@ -113,7 +113,7 @@ namespace PEBakery.Core.Tests
                 (Script? newScript, LogInfo log) = updater.UpdateScript(sc, true);
 
                 // Validate updated script
-                Console.WriteLine(log.ToString());
+                Console.WriteLine(log);
                 Assert.IsNotNull(newScript);
                 Assert.IsTrue(newScript.TidyVersion.Equals("1.2", StringComparison.Ordinal));
                 Assert.AreEqual(SelectedState.True, newScript.Selected);

--- a/PEBakery.Core.Tests/FileUpdaterTests.cs
+++ b/PEBakery.Core.Tests/FileUpdaterTests.cs
@@ -85,7 +85,7 @@ namespace PEBakery.Core.Tests
         #region UpdateScript
         [TestMethod]
         [TestCategory("FileUpdater")]
-        public async Task UpdateScript()
+        public void UpdateScript()
         {
             string destDir = FileHelper.GetTempDir();
             try
@@ -95,7 +95,9 @@ namespace PEBakery.Core.Tests
                 string workScriptFile = Path.Combine(destDir, "PreserveInterface.script");
                 string workScriptTreePath = Path.Combine("TestSuite", "Updater", "PreserveInterface.script");
                 File.Copy(srcScriptFile, workScriptFile);
-                IniReadWriter.WriteKey(workScriptFile, "ScriptUpdate", "Url", @$"http://localhost:{TestSetup.ServerPort}/Updater/Standalone/PreserveInterface_r2.script");
+                string updateUrl = @$"{TestSetup.UrlRoot}/Updater/Standalone/PreserveInterface_r2.script";
+                IniReadWriter.WriteKey(workScriptFile, "ScriptUpdate", "Url", updateUrl);
+                Console.WriteLine($"UpdateUrl: {updateUrl}");
 
                 Project p = EngineTests.Project;
                 Script? sc = p.LoadScriptRuntime(workScriptFile, workScriptTreePath, new LoadScriptRuntimeOptions
@@ -108,7 +110,7 @@ namespace PEBakery.Core.Tests
 
                 // Run an update
                 FileUpdater updater = new FileUpdater(EngineTests.Project, null, null);
-                (Script? newScript, LogInfo log) = await updater.UpdateScriptAsync(sc, true);
+                (Script? newScript, LogInfo log) = updater.UpdateScript(sc, true);
 
                 // Validate updated script
                 Console.WriteLine(log);

--- a/PEBakery.Core.Tests/FileUpdaterTests.cs
+++ b/PEBakery.Core.Tests/FileUpdaterTests.cs
@@ -113,7 +113,7 @@ namespace PEBakery.Core.Tests
                 (Script? newScript, LogInfo log) = updater.UpdateScript(sc, true);
 
                 // Validate updated script
-                Console.WriteLine(log);
+                Console.WriteLine(log.ToString());
                 Assert.IsNotNull(newScript);
                 Assert.IsTrue(newScript.TidyVersion.Equals("1.2", StringComparison.Ordinal));
                 Assert.AreEqual(SelectedState.True, newScript.Selected);

--- a/PEBakery.Core/FileUpdater.cs
+++ b/PEBakery.Core/FileUpdater.cs
@@ -368,6 +368,10 @@ namespace PEBakery.Core
                 Script? newScript = _p.RefreshScript(sc);
                 if (newScript == null)
                     return new ResultReport<Script>(true, null, $"Script [{sc.Title}] refresh failure");
+                Console.WriteLine($"TEMP ScriptFile: {tempScriptFile}, {sc.DirectRealPath}");
+                Console.WriteLine($"TEMP Title: {remoteScript.Title}, {newScript.Title}");
+                Console.WriteLine($"TEMP RawVersion: {remoteScript.RawVersion}, {newScript.RawVersion}");
+                Console.WriteLine($"TEMP Version: {remoteScript.ParsedVersion}, {newScript.ParsedVersion}");
 
                 // Return updated script instance
                 return new ResultReport<Script>(true, newScript, $"Updated script [{sc.Title}] to [v{sc.RawVersion}] from [v{newScript.RawVersion}]");

--- a/PEBakery.Core/FileUpdater.cs
+++ b/PEBakery.Core/FileUpdater.cs
@@ -369,8 +369,6 @@ namespace PEBakery.Core
                 if (newScript == null)
                     return new ResultReport<Script>(true, null, $"Script [{sc.Title}] refresh failure");
 
-                Console.WriteLine($"TEMP ScriptFile: {File.ReadAllText(tempScriptFile)}");
-
                 // Return updated script instance
                 return new ResultReport<Script>(true, newScript, $"Updated script [{sc.Title}] to [v{sc.RawVersion}] from [v{newScript.RawVersion}]");
             }

--- a/PEBakery.Core/FileUpdater.cs
+++ b/PEBakery.Core/FileUpdater.cs
@@ -368,10 +368,8 @@ namespace PEBakery.Core
                 Script? newScript = _p.RefreshScript(sc);
                 if (newScript == null)
                     return new ResultReport<Script>(true, null, $"Script [{sc.Title}] refresh failure");
-                Console.WriteLine($"TEMP ScriptFile: {tempScriptFile}, {sc.DirectRealPath}");
-                Console.WriteLine($"TEMP Title: {remoteScript.Title}, {newScript.Title}");
-                Console.WriteLine($"TEMP RawVersion: {remoteScript.RawVersion}, {newScript.RawVersion}");
-                Console.WriteLine($"TEMP Version: {remoteScript.ParsedVersion}, {newScript.ParsedVersion}");
+
+                Console.WriteLine($"TEMP ScriptFile: {File.ReadAllText(tempScriptFile)}");
 
                 // Return updated script instance
                 return new ResultReport<Script>(true, newScript, $"Updated script [{sc.Title}] to [v{sc.RawVersion}] from [v{newScript.RawVersion}]");

--- a/mstest.runsettings
+++ b/mstest.runsettings
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <RunSettings>
   <MSTest>
-    <Parallelize>
+    <!-- Parallelize>
       <Workers>0</Workers>
       <Scope>ClassLevel</Scope>
-    </Parallelize>
+    </Parallelize -->
   </MSTest>
   <DataCollectionRunSettings>
     <DataCollectors>


### PR DESCRIPTION
Parallel test execution is sometimes wrecking Azure Pipelines test run, so disable it.