### PR TITLE
Implement Data Flow Analysis on CodeOptimizer

### DIFF
--- a/PEBakery.Core.Tests/CodeOptimizerTests.cs
+++ b/PEBakery.Core.Tests/CodeOptimizerTests.cs
@@ -1,0 +1,63 @@
+﻿/*
+    Copyright (C) 2022 Hajin Jang
+    Licensed under GPL 3.0
+ 
+    PEBakery is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    Additional permission under GNU GPL version 3 section 7
+
+    If you modify this program, or any covered work, by linking
+    or combining it with external libraries, containing parts
+    covered by the terms of various license, the licensors of
+    this program grant you additional permission to convey the
+    resulting work. An external library is a library which is
+    not derived from or based on this program. 
+*/
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PEBakery.Core.Tests
+{
+    [TestClass]
+    public class CodeOptimizerTests
+    {
+        [TestMethod]
+        [TestCategory(nameof(CodeOptimizer))]
+        public void DepedencyCheck()
+        {
+            string[] lines = new string[]
+            {
+                "IniRead,%SrcFile%,Section,Key,%Dest%",
+                "IniRead,%SrcFile%,%Dest%,Key,%Dest%",
+                "IniRead,%SrcFile%,Section,Key,%Dest%",
+            };
+            CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
+            Assert.IsTrue(errorLogs.Count == 0);
+            Assert.AreEqual(2, cmds.Length);
+
+            Assert.IsTrue(cmds[0].Info is CodeInfo_IniRead);
+            {
+                Assert.IsTrue(cmds[1].Info is CodeInfo_IniReadOp);
+                CodeInfo_IniReadOp opCmdInfo = (CodeInfo_IniReadOp)cmds[1].Info;
+                Assert.AreEqual(2, opCmdInfo.Infos.Count);
+            }
+
+        }
+    }
+}

--- a/PEBakery.Core.Tests/CodeOptimizerTests.cs
+++ b/PEBakery.Core.Tests/CodeOptimizerTests.cs
@@ -28,9 +28,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PEBakery.Core.Tests
 {
@@ -39,25 +36,217 @@ namespace PEBakery.Core.Tests
     {
         [TestMethod]
         [TestCategory(nameof(CodeOptimizer))]
-        public void DepedencyCheck()
+        public void DepedencyHazard()
+        {
+            // Groups should be breaked 1-2
+            {
+                string[] lines = new string[]
+                {
+                    "IniRead,%SrcFile%,Section,Key,%Dest%",
+                    // -- Should be separated --
+                    "IniRead,%SrcFile%,%Dest%,Key,%Dest%",
+                    "IniRead,%SrcFile%,Section,Key,%Dest%",
+                };
+                CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
+                Assert.IsTrue(errorLogs.Count == 0);
+                Assert.AreEqual(2, cmds.Length);
+
+                IsSingleCommand(cmds[0], CodeType.IniRead);
+                IsOptimizedCommand(cmds[1], CodeType.IniReadOp, 2);
+            }
+            // Groups should be breaked 2-1
+            {
+                string[] lines = new string[]
+                {
+                    "IniRead,%SrcFile%,Section,Key,%Dest%",
+                    "IniRead,%SrcFile%,Section,Key,%Dest%",
+                    // -- Should be separated --
+                    "IniRead,%SrcFile%,%Dest%,Key,%Dest%",
+                };
+                CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
+                Assert.IsTrue(errorLogs.Count == 0);
+                Assert.AreEqual(2, cmds.Length);
+
+                IsOptimizedCommand(cmds[0], CodeType.IniReadOp, 2);
+                IsSingleCommand(cmds[1], CodeType.IniRead);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(nameof(CodeOptimizer))]
+        public void MiddleComment()
         {
             string[] lines = new string[]
             {
-                "IniRead,%SrcFile%,Section,Key,%Dest%",
-                "IniRead,%SrcFile%,%Dest%,Key,%Dest%",
-                "IniRead,%SrcFile%,Section,Key,%Dest%",
+                "IniRead,%SrcFile%,A,B,%D1%",
+                "IniRead,%SrcFile%,A,B,%D2%",
+                "// Comment HERE",
+                "IniRead,%SrcFile%,A,B,%D3%",
             };
             CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
             Assert.IsTrue(errorLogs.Count == 0);
-            Assert.AreEqual(2, cmds.Length);
+            Assert.AreEqual(1, cmds.Length);
 
-            Assert.IsTrue(cmds[0].Info is CodeInfo_IniRead);
+            IsOptimizedCommand(cmds[0], CodeType.IniReadOp, 3);
+        }
+
+        [TestMethod]
+        [TestCategory(nameof(CodeOptimizer))]
+        public void MultipleCodeTypes()
+        {
+            // Without comments
             {
-                Assert.IsTrue(cmds[1].Info is CodeInfo_IniReadOp);
-                CodeInfo_IniReadOp opCmdInfo = (CodeInfo_IniReadOp)cmds[1].Info;
-                Assert.AreEqual(2, opCmdInfo.Infos.Count);
+                string[] lines = new string[]
+                {
+                    "IniRead,%SrcFile%,A,B,%D1%",
+                    "IniRead,%SrcFile%,A,B,%D2%",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Windows\",%Target%",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Program Files\",%Target%",
+                };
+                CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
+                Assert.IsTrue(errorLogs.Count == 0);
+                Assert.AreEqual(2, cmds.Length);
+
+                IsOptimizedCommand(cmds[0], CodeType.IniReadOp, 2);
+                IsOptimizedCommand(cmds[1], CodeType.WimExtractOp, 2);
             }
 
+            // With comments (1)
+            {
+                string[] lines = new string[]
+                {
+                    "IniRead,%SrcFile%,A,B,%D1%",
+                    "// Comment HERE",
+                    "IniRead,%SrcFile%,A,B,%D2%",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Windows\",%Target%",
+                    "// Comment HERE",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Program Files\",%Target%",
+                };
+                CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
+                Assert.IsTrue(errorLogs.Count == 0);
+                Assert.AreEqual(2, cmds.Length);
+
+                IsOptimizedCommand(cmds[0], CodeType.IniReadOp, 2);
+                IsOptimizedCommand(cmds[1], CodeType.WimExtractOp, 2);
+            }
+
+            // With comments (2)
+            {
+                string[] lines = new string[]
+                {
+                    "IniRead,%SrcFile%,A,B,%D1%",
+                    "IniRead,%SrcFile%,A,B,%D2%",
+                    "// Comment HERE",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Windows\",%Target%",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Program Files\",%Target%",
+                };
+                CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
+                Assert.IsTrue(errorLogs.Count == 0);
+                Assert.AreEqual(3, cmds.Length);
+
+                IsOptimizedCommand(cmds[0], CodeType.IniReadOp, 2);
+                IsSingleCommand(cmds[1], CodeType.Comment);
+                IsOptimizedCommand(cmds[2], CodeType.WimExtractOp, 2);
+            }
+
+            // With unoptimizable command
+            {
+                string[] lines = new string[]
+                {
+                    "IniRead,%SrcFile%,A,B,%D1%",
+                    "IniRead,%SrcFile%,A,B,%D2%",
+                    "Echo,Dummy",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Windows\",%Target%",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Program Files\",%Target%",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Program Files (x86)\",%Target%",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Boot\",%Temp%",
+                    "WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Users\",%Temp%",
+                };
+                CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
+                Assert.IsTrue(errorLogs.Count == 0);
+                Assert.AreEqual(4, cmds.Length);
+
+                IsOptimizedCommand(cmds[0], CodeType.IniReadOp, 2);
+                IsSingleCommand(cmds[1], CodeType.Echo);
+                IsOptimizedCommand(cmds[2], CodeType.WimExtractOp, 3);
+                IsOptimizedCommand(cmds[3], CodeType.WimExtractOp, 2);
+            }
         }
+
+        [TestMethod]
+        [TestCategory(nameof(CodeOptimizer))]
+        public void Complex()
+        {
+            // ReadInterface, IniRead, WimExtract, WimPathOp
+            string[] lines = new string[]
+            {
+                "System,SetLocal",
+                "ReadInterface,Text,%ScriptFile%,Interface,FileBox01,%IfaceSection%",
+                "ReadInterface,Visible,%ScriptFile%,%IfaceSection%,ActiveMarker,%isActive%",
+                "ReadInterface,Value,%ScriptFile%,%IfaceSection%,Index01,%wimIndex%",
+                "If,%isActive%,Equal,True,Begin",
+                "  Set,%Target%,%BaseDir%\\Target",
+                "  WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Windows\",%Target%",
+                "  WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Program Files\",%Target%",
+                "  WimExtract,\"%BaseDir%\\install.wim\",3,\"\\Program Files (x86)\",%Target%",
+                "  Echo,Extracting...",
+                "  Echo,\"This won't take long...\"",
+                "  WimExtract,\"%BaseDir%\\install.wim\",2,\"\\Boot\",%Target%",
+                "  WimExtract,\"%BaseDir%\\install.wim\",2,\"\\Users\",%Target%",
+                "  ; Also copy fonts",
+                "  WimExtract,\"%BaseDir%\\install.wim\",2,\"\\Windows\\Fonts\",%Target%",
+                "End",
+                "Else,Begin",
+                "  IniRead,%SrcFile%,A,B,%D1%",
+                "  IniRead,%SrcFile%,C,D,%D2%",
+                "  // Just read some values.",
+                "  IniRead,%SrcFile%,E,F,%D3%",
+                "  IniRead,%D1%,%D2%,%D3%,%D4%",
+                "End",
+                "Echo,Dummy",
+                "WriteInterface,Resource,%ScriptFile%,Interface,Button01,Image.png",
+                "WriteInterface,PosX,%ScriptFile%,Interface,Button01,100",
+            };
+            CodeCommand[] cmds = EngineTests.ParseLines(lines, out List<LogInfo> errorLogs);
+            Assert.IsTrue(errorLogs.Count == 0);
+            Assert.AreEqual(7, cmds.Length);
+
+            IsSingleCommand(cmds[0], CodeType.System);
+            IsSingleCommand(cmds[1], CodeType.ReadInterface);
+            IsOptimizedCommand(cmds[2], CodeType.ReadInterfaceOp, 2);
+            IsSingleCommand(cmds[3], CodeType.If);
+            IsSingleCommand(cmds[4], CodeType.Else);
+            IsSingleCommand(cmds[5], CodeType.Echo);
+            IsOptimizedCommand(cmds[6], CodeType.WriteInterfaceOp, 2);
+
+            CodeInfo_If ifInfo = (CodeInfo_If)cmds[3].Info;
+            IsSingleCommand(ifInfo.Link[0], CodeType.Set);
+            IsOptimizedCommand(ifInfo.Link[1], CodeType.WimExtractOp, 3);
+            IsSingleCommand(ifInfo.Link[2], CodeType.Echo);
+            IsSingleCommand(ifInfo.Link[3], CodeType.Echo);
+            IsOptimizedCommand(ifInfo.Link[4], CodeType.WimExtractOp, 3);
+
+            CodeInfo_Else elseInfo = (CodeInfo_Else)cmds[4].Info;
+            IsOptimizedCommand(elseInfo.Link[0], CodeType.IniReadOp, 3);
+            IsSingleCommand(elseInfo.Link[1], CodeType.IniRead);
+
+        }
+
+        #region Utility
+        public static void IsSingleCommand(CodeCommand actCmd, CodeType expType)
+        {
+            Assert.AreEqual(expType, actCmd.Type);
+            Assert.IsTrue(actCmd.Info is not CodeOptInfo);
+        }
+
+        public static void IsOptimizedCommand(CodeCommand actCmd, CodeType expType, int mergedLines)
+        {
+            Assert.AreEqual(expType, actCmd.Type);
+            Assert.IsTrue(actCmd.Info is CodeOptInfo);
+            Assert.AreEqual(mergedLines, ((CodeOptInfo)actCmd.Info).Cmds.Count);
+        }
+        #endregion
     }
+
+
 }

--- a/PEBakery.Core.Tests/Command/CommandListTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandListTests.cs
@@ -358,7 +358,7 @@ namespace PEBakery.Core.Tests.Command
         {
             EngineState s = EngineTests.CreateEngineState();
 
-            
+
             WriteTemplate(s, "List,Range,%ListStr%,0,7,1", null, "0|1|2|3|4|5|6");
             WriteTemplate(s, "List,Range,%ListStr%,0,7,2", null, "0|2|4|6");
             WriteTemplate(s, "List,Range,%ListStr%,0,7,8", null, "0");
@@ -373,7 +373,7 @@ namespace PEBakery.Core.Tests.Command
             WriteTemplate(s, "List,Range,%ListStr%,0,7,-1", null, null, ErrorCheck.RuntimeError);
             WriteTemplate(s, "List,Range,%ListStr%,7,0,1", null, null, ErrorCheck.RuntimeError);
             WriteTemplate(s, "List,Range,%ListStr%,7,0,2", null, null, ErrorCheck.RuntimeError);
-            
+
             WriteTemplate(s, "List,Range,%ListStr%,0,", null, null, ErrorCheck.ParserError);
             WriteTemplate(s, "List,Range,%ListStr%,0,7", null, null, ErrorCheck.ParserError);
             WriteTemplate(s, "List,Range,%ListStr%,7,0", null, null, ErrorCheck.ParserError);

--- a/PEBakery.Core.Tests/EngineTests.cs
+++ b/PEBakery.Core.Tests/EngineTests.cs
@@ -401,6 +401,17 @@ namespace PEBakery.Core.Tests
         }
         #endregion
 
+        #region ParseLines
+        public static CodeCommand[] ParseLines(IReadOnlyList<string> lines, out List<LogInfo> errorLogs)
+        {
+            ScriptSection section = DummySection();
+            CodeParser parser = new CodeParser(section, Global.Setting, Project.Compat);
+            CodeCommand[] cmds;
+            (cmds, errorLogs) = parser.ParseStatements(lines);
+            return cmds;
+        }
+        #endregion
+
         #region CheckErrorLogs
         public static void CheckErrorLogs(List<LogInfo> logs, ErrorCheck check)
         {

--- a/PEBakery.Core.Tests/TestSetup.cs
+++ b/PEBakery.Core.Tests/TestSetup.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PEBakery.Core.ViewModels;

--- a/PEBakery.Core/CodeCommand.cs
+++ b/PEBakery.Core/CodeCommand.cs
@@ -203,6 +203,27 @@ namespace PEBakery.Core
             Embed = embed;
         }
     }
+
+    public class CodeOptInfo : CodeInfo
+    {
+        public List<CodeCommand> Cmds { get; private set; }
+
+        public CodeOptInfo(IEnumerable<CodeCommand> cmds)
+        {
+            if (cmds.Count() == 0)
+                throw new InternalException($"No commands to optmize in [{nameof(CodeOptInfo)}]");
+
+            if (cmds is List<CodeCommand> cmdList)
+                Cmds = cmdList;
+            else
+                Cmds = cmds.ToList();
+        }
+
+        public IEnumerable<T> Infos<T>() where T : CodeInfo
+        {
+            return Cmds.Where(x => x.Info is T).Select(x => (T)x.Info);
+        }
+    }
     #endregion
 
     #region CodeInfo 00 - Misc
@@ -860,34 +881,6 @@ namespace PEBakery.Core
         }
     }
 
-    public class CodeInfo_TXTAddLineOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; set; }
-        public List<CodeInfo_TXTAddLine> Infos
-        {
-            get
-            {
-                List<CodeInfo_TXTAddLine> infos = new List<CodeInfo_TXTAddLine>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_TXTAddLine info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_TXTAddLine)}");
-                        continue;
-                    }
-
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_TXTAddLineOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
-        }
-    }
-
     public class CodeInfo_TXTReplace : CodeInfo
     { // TXTReplace,<FileName>,<OldStr>,<NewStr>
         public string FileName { get; private set; }
@@ -923,33 +916,6 @@ namespace PEBakery.Core
         }
     }
 
-    public class CodeInfo_TXTReplaceOp : CodeInfo
-    { // TXTReplace,<FileName>,<OldStr>,<NewStr>
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_TXTReplace> Infos
-        {
-            get
-            {
-                List<CodeInfo_TXTReplace> infos = new List<CodeInfo_TXTReplace>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_TXTReplace info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_TXTReplace)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_TXTReplaceOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
-        }
-    }
-
     public class CodeInfo_TXTDelLine : CodeInfo
     { // TXTDelLine,<FileName>,<DeleteLine>
         public string FileName { get; private set; }
@@ -978,33 +944,6 @@ namespace PEBakery.Core
             b.Append(',');
             b.Append(DeleteLine);
             return b.ToString();
-        }
-    }
-
-    public class CodeInfo_TXTDelLineOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_TXTDelLine> Infos
-        {
-            get
-            {
-                List<CodeInfo_TXTDelLine> infos = new List<CodeInfo_TXTDelLine>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_TXTDelLine info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_TXTDelLine)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_TXTDelLineOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
         }
     }
 
@@ -1096,33 +1035,6 @@ namespace PEBakery.Core
         }
     }
 
-    public class CodeInfo_IniReadOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_IniRead> Infos
-        {
-            get
-            {
-                List<CodeInfo_IniRead> infos = new List<CodeInfo_IniRead>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_IniRead info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_IniRead)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_IniReadOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
-        }
-    }
-
     public class CodeInfo_IniWrite : CodeInfo
     { // IniWrite,<FileName>,<Section>,<Key>,<Value>
         public string FileName { get; private set; }
@@ -1162,33 +1074,6 @@ namespace PEBakery.Core
         }
     }
 
-    public class CodeInfo_IniWriteOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_IniWrite> Infos
-        {
-            get
-            {
-                List<CodeInfo_IniWrite> infos = new List<CodeInfo_IniWrite>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_IniWrite info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_IniWrite)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_IniWriteOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
-        }
-    }
-
     public class CodeInfo_IniDelete : CodeInfo
     { // IniDelete,<FileName>,<Section>,<Key>
         public string FileName { get; private set; }
@@ -1221,33 +1106,6 @@ namespace PEBakery.Core
             b.Append(',');
             b.Append(Key);
             return b.ToString();
-        }
-    }
-
-    public class CodeInfo_IniDeleteOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_IniDelete> Infos
-        {
-            get
-            {
-                List<CodeInfo_IniDelete> infos = new List<CodeInfo_IniDelete>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_IniDelete info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_IniDelete)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_IniDeleteOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
         }
     }
 
@@ -1295,33 +1153,6 @@ namespace PEBakery.Core
         }
     }
 
-    public class CodeInfo_IniReadSectionOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_IniReadSection> Infos
-        {
-            get
-            {
-                List<CodeInfo_IniReadSection> infos = new List<CodeInfo_IniReadSection>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_IniReadSection info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_IniReadSection)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_IniReadSectionOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
-        }
-    }
-
     public class CodeInfo_IniAddSection : CodeInfo
     { // IniAddSection,<FileName>,<Section>
         public string FileName { get; private set; }
@@ -1353,33 +1184,6 @@ namespace PEBakery.Core
         }
     }
 
-    public class CodeInfo_IniAddSectionOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_IniAddSection> Infos
-        {
-            get
-            {
-                List<CodeInfo_IniAddSection> infos = new List<CodeInfo_IniAddSection>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_IniAddSection info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_IniAddSection)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_IniAddSectionOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
-        }
-    }
-
     public class CodeInfo_IniDeleteSection : CodeInfo
     { // IniDeleteSection,<FileName>,<Section>
         public string FileName { get; private set; }
@@ -1408,33 +1212,6 @@ namespace PEBakery.Core
             b.Append(',');
             b.Append(Section);
             return b.ToString();
-        }
-    }
-
-    public class CodeInfo_IniDeleteSectionOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_IniDeleteSection> Infos
-        {
-            get
-            {
-                List<CodeInfo_IniDeleteSection> infos = new List<CodeInfo_IniDeleteSection>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_IniDeleteSection info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_IniDeleteSection)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_IniDeleteSectionOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
         }
     }
 
@@ -1475,33 +1252,6 @@ namespace PEBakery.Core
             if (Append)
                 b.Append(",APPEND");
             return b.ToString();
-        }
-    }
-
-    public class CodeInfo_IniWriteTextLineOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_IniWriteTextLine> Infos
-        {
-            get
-            {
-                List<CodeInfo_IniWriteTextLine> infos = new List<CodeInfo_IniWriteTextLine>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_IniWriteTextLine info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_IniWriteTextLine)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_IniWriteTextLineOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
         }
     }
 
@@ -1740,33 +1490,6 @@ namespace PEBakery.Core
             if (NoAttribFlag)
                 b.Append(",NOATTRIB");
             return b.ToString();
-        }
-    }
-
-    public class CodeInfo_WimExtractOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_WimExtract> Infos
-        {
-            get
-            {
-                List<CodeInfo_WimExtract> infos = new List<CodeInfo_WimExtract>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_WimExtract info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_WimExtract)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_WimExtractOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
         }
     }
 
@@ -2217,16 +1940,6 @@ namespace PEBakery.Core
             if (RebuildFlag)
                 b.Append(",REBUILD");
             return b.ToString();
-        }
-    }
-
-    public class CodeInfo_WimPathOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-
-        public CodeInfo_WimPathOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
         }
     }
 
@@ -2691,33 +2404,6 @@ namespace PEBakery.Core
         }
     }
 
-    public class CodeInfo_VisibleOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_Visible> Infos
-        {
-            get
-            {
-                List<CodeInfo_Visible> infos = new List<CodeInfo_Visible>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_Visible info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_Visible)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_VisibleOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
-        }
-    }
-
     public enum InterfaceElement
     {
         // General
@@ -2789,33 +2475,6 @@ namespace PEBakery.Core
         }
     }
 
-    public class CodeInfo_ReadInterfaceOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_ReadInterface> Infos
-        {
-            get
-            {
-                List<CodeInfo_ReadInterface> infos = new List<CodeInfo_ReadInterface>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_ReadInterface info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_ReadInterface)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_ReadInterfaceOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
-        }
-    }
-
     [Serializable]
     public class CodeInfo_WriteInterface : CodeInfo
     { // WriteInterface,<Element>,<ScriptFile>,<Section>,<Key>,<Value>,[Delim=<Str>]
@@ -2865,33 +2524,6 @@ namespace PEBakery.Core
                 b.Append(Delim);
             }
             return b.ToString();
-        }
-    }
-
-    public class CodeInfo_WriteInterfaceOp : CodeInfo
-    {
-        public List<CodeCommand> Cmds { get; private set; }
-        public List<CodeInfo_WriteInterface> Infos
-        {
-            get
-            {
-                List<CodeInfo_WriteInterface> infos = new List<CodeInfo_WriteInterface>();
-                foreach (CodeCommand cmd in Cmds)
-                {
-                    if (cmd.Info is not CodeInfo_WriteInterface info)
-                    {
-                        Debug.Assert(false, $"{nameof(CodeInfo)} is not {nameof(CodeInfo_WriteInterface)}");
-                        continue;
-                    }
-                    infos.Add(info);
-                }
-                return infos;
-            }
-        }
-
-        public CodeInfo_WriteInterfaceOp(List<CodeCommand> cmds)
-        {
-            Cmds = new List<CodeCommand>(cmds);
         }
     }
 

--- a/PEBakery.Core/CodeCommand.cs
+++ b/PEBakery.Core/CodeCommand.cs
@@ -145,7 +145,7 @@ namespace PEBakery.Core
     public class CodeInfo
     {
         #region Optimize
-        public virtual bool OptimizeCompare(CodeInfo info) => false;
+        public virtual bool IsOptimizable(CodeInfo info) => false;
         #endregion
 
         #region Deprecate
@@ -839,7 +839,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(FileName, Line, Mode);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_TXTAddLine info)
                 return false;
@@ -903,7 +903,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(FileName, OldStr, NewStr);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_TXTReplace info)
                 return false;
@@ -963,7 +963,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(FileName, DeleteLine);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_TXTDelLine info)
                 return false;
@@ -1068,7 +1068,7 @@ namespace PEBakery.Core
         public override HashSet<string> InVars() => CreateInVars(FileName, Section, Key, DefaultValue);
         public override HashSet<string> OutVars() => CreateOutVars(DestVar);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_IniRead info)
                 return false;
@@ -1140,7 +1140,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(FileName, Section, Key, Value);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_IniWrite info)
                 return false;
@@ -1204,7 +1204,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(FileName, Section, Key);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_IniDelete info)
                 return false;
@@ -1269,7 +1269,7 @@ namespace PEBakery.Core
         public override HashSet<string> InVars() => CreateInVars(FileName, Section, Delim);
         public override HashSet<string> OutVars() => CreateOutVars(DestVar);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             CodeInfo_IniReadSection info = (CodeInfo_IniReadSection)cmpInfo;
             if (info == null)
@@ -1335,7 +1335,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(FileName, Section);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_IniAddSection info)
                 return false;
@@ -1393,7 +1393,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(FileName, Section);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_IniDeleteSection info)
                 return false;
@@ -1455,7 +1455,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(FileName, Section, Line);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_IniWriteTextLine info)
                 return false;
@@ -1693,7 +1693,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(SrcWim, ImageIndex, ExtractPath, DestDir, Split);
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         { // Condition : Every argument except DestDir should be identical
             if (cmpInfo is not CodeInfo_WimExtract info)
                 return false;
@@ -2035,7 +2035,7 @@ namespace PEBakery.Core
             PreserveFlag = preserveFlag;
         }
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is CodeInfo_WimPathAdd addInfo)
             {
@@ -2107,7 +2107,7 @@ namespace PEBakery.Core
             Path = path;
         }
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is CodeInfo_WimPathAdd addInfo)
             {
@@ -2175,7 +2175,7 @@ namespace PEBakery.Core
             DestPath = destPath;
         }
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is CodeInfo_WimPathAdd addInfo)
             {
@@ -2683,7 +2683,7 @@ namespace PEBakery.Core
             Visibility = visibility;
         }
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo) => true;
+        public override bool IsOptimizable(CodeInfo cmpInfo) => true;
 
         public override string ToString()
         {
@@ -2759,7 +2759,7 @@ namespace PEBakery.Core
             Delim = delim;
         }
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_ReadInterface info)
                 return false;
@@ -2838,7 +2838,7 @@ namespace PEBakery.Core
             Delim = delim;
         }
 
-        public override bool OptimizeCompare(CodeInfo cmpInfo)
+        public override bool IsOptimizable(CodeInfo cmpInfo)
         {
             if (cmpInfo is not CodeInfo_WriteInterface info)
                 return false;
@@ -4999,7 +4999,7 @@ namespace PEBakery.Core
     public class CodeInfo_Return : CodeInfo
     { // Return,[ReturnValue]
         public string? ReturnValue { get; private set; }
-        
+
         public CodeInfo_Return(string? returnValue)
         {
             ReturnValue = returnValue;

--- a/PEBakery.Core/CodeOptimizer.cs
+++ b/PEBakery.Core/CodeOptimizer.cs
@@ -25,6 +25,7 @@
     not derived from or based on this program. 
 */
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -59,493 +60,7 @@ namespace PEBakery.Core
         #endregion
 
         #region OptimizeCommands
-        public static List<CodeCommand> Optimize(List<CodeCommand> codes)
-        {
-            List<CodeCommand> opCodes = InternalOptimize(codes);
-            foreach (CodeCommand cmd in opCodes)
-            {
-                switch (cmd.Type)
-                {
-                    case CodeType.If:
-                        {
-                            if (cmd.Info is null)
-                                throw new InvalidCodeCommandException("cmd.Info is null", cmd);
-                            CodeInfo_If info = (CodeInfo_If)cmd.Info;
-                            info.Link = Optimize(info.Link);
-                        }
-                        break;
-                    case CodeType.Else:
-                        {
-                            if (cmd.Info is null)
-                                throw new InvalidCodeCommandException("cmd.Info is null", cmd);
-                            CodeInfo_Else info = (CodeInfo_Else)cmd.Info;
-                            info.Link = Optimize(info.Link);
-                        }
-                        break;
-                }
-            }
-            return opCodes;
-        }
 
-        private static List<CodeCommand> InternalOptimize(List<CodeCommand> cmds)
-        {
-            List<CodeCommand> optimized = new List<CodeCommand>(cmds.Count);
-
-            Dictionary<CodeType, List<CodeCommand>> opDict = OptimizedCodeTypes.ToDictionary(x => x, x => new List<CodeCommand>(cmds.Count / 2));
-
-            CodeType s = CodeType.None;
-            foreach (CodeCommand cmd in cmds)
-            {
-                bool loopAgain;
-                do
-                {
-                    loopAgain = false;
-                    switch (s)
-                    {
-                        #region Default
-                        case CodeType.None:
-                            switch (cmd.Type)
-                            {
-                                case CodeType.TXTAddLine:
-                                case CodeType.TXTReplace:
-                                case CodeType.TXTDelLine:
-                                case CodeType.IniRead:
-                                case CodeType.IniWrite:
-                                case CodeType.IniDelete:
-                                case CodeType.IniReadSection:
-                                case CodeType.IniAddSection:
-                                case CodeType.IniDeleteSection:
-                                case CodeType.IniWriteTextLine:
-                                case CodeType.Visible:
-                                case CodeType.ReadInterface:
-                                case CodeType.WriteInterface:
-                                case CodeType.WimExtract:
-                                    s = cmd.Type;
-                                    opDict[cmd.Type].Add(cmd);
-                                    break;
-                                case CodeType.WimPathAdd:
-                                case CodeType.WimPathDelete:
-                                case CodeType.WimPathRename:
-                                    s = CodeType.WimPathAdd; // Use WimPathAdd as representative
-                                    opDict[CodeType.WimPathAdd].Add(cmd);
-                                    break;
-                                default:
-                                    optimized.Add(cmd);
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region TXTAddLine
-                        case CodeType.TXTAddLine:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_TXTAddLine, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.TXTAddLine:
-                                    {
-                                        CodeInfo_TXTAddLine firstInfo = (CodeInfo_TXTAddLine)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region TXTReplace
-                        case CodeType.TXTReplace:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_TXTReplace);
-                            switch (cmd.Type)
-                            {
-                                case CodeType.TXTReplace:
-                                    {
-                                        CodeInfo_TXTReplace firstInfo = (CodeInfo_TXTReplace)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region TXTDelLine
-                        case CodeType.TXTDelLine:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_TXTDelLine, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.TXTDelLine:
-                                    {
-                                        CodeInfo_TXTDelLine firstInfo = (CodeInfo_TXTDelLine)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region IniRead
-                        case CodeType.IniRead:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_IniRead, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.IniRead:
-                                    {
-                                        CodeInfo_IniRead firstInfo = (CodeInfo_IniRead)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region IniWrite
-                        case CodeType.IniWrite:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_IniWrite, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.IniWrite:
-                                    {
-                                        CodeInfo_IniWrite firstInfo = (CodeInfo_IniWrite)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region IinDelete
-                        case CodeType.IniDelete:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_IniDelete, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.IniDelete:
-                                    {
-                                        CodeInfo_IniDelete firstInfo = (CodeInfo_IniDelete)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region IniReadSection
-                        case CodeType.IniReadSection:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_IniReadSection);
-                            switch (cmd.Type)
-                            {
-                                case CodeType.IniReadSection:
-                                    {
-                                        CodeInfo_IniReadSection firstInfo = (CodeInfo_IniReadSection)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region IniAddSection
-                        case CodeType.IniAddSection:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_IniAddSection, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.IniAddSection:
-                                    {
-                                        CodeInfo_IniAddSection firstInfo = (CodeInfo_IniAddSection)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region IniDeleteSection
-                        case CodeType.IniDeleteSection:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_IniDeleteSection, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.IniDeleteSection:
-                                    {
-                                        CodeInfo_IniDeleteSection firstInfo = (CodeInfo_IniDeleteSection)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region IniWriteTextLine
-                        case CodeType.IniWriteTextLine:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_IniWriteTextLine, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.IniWriteTextLine:
-                                    {
-                                        CodeInfo_IniWriteTextLine firstInfo = (CodeInfo_IniWriteTextLine)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region Visible
-                        case CodeType.Visible:
-                            switch (cmd.Type)
-                            {
-                                case CodeType.Visible:
-                                    opDict[s].Add(cmd);
-                                    break;
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region ReadInterface
-                        case CodeType.ReadInterface:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_ReadInterface, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.ReadInterface:
-                                    {
-                                        CodeInfo_ReadInterface firstInfo = (CodeInfo_ReadInterface)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region WriteInterface
-                        case CodeType.WriteInterface:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_WriteInterface, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.WriteInterface:
-                                    {
-                                        CodeInfo_WriteInterface firstInfo = (CodeInfo_WriteInterface)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region WimExtract
-                        case CodeType.WimExtract:
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_WimExtract, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.WimExtract:
-                                    {
-                                        CodeInfo_WimExtract firstInfo = (CodeInfo_WimExtract)opDict[s][0].Info;
-                                        if (firstInfo.OptimizeCompare(cmd.Info))
-                                            opDict[s].Add(cmd);
-                                        else
-                                            goto default;
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region WimPath Series
-                        case CodeType.WimPathAdd: // Use WimPathAdd as a representative of WimPath{Add, Delete, Rename}
-                            Debug.Assert(opDict[s][0].Info is CodeInfo_WimPathAdd ||
-                                         opDict[s][0].Info is CodeInfo_WimPathDelete ||
-                                         opDict[s][0].Info is CodeInfo_WimPathRename, "Invalid CodeInfo");
-                            switch (cmd.Type)
-                            {
-                                case CodeType.WimPathAdd:
-                                case CodeType.WimPathDelete:
-                                case CodeType.WimPathRename:
-                                    {
-                                        CodeCommand firstCmd = opDict[s][0];
-                                        if (firstCmd.Type == CodeType.WimPathAdd)
-                                        {
-                                            CodeInfo_WimPathAdd firstInfo = (CodeInfo_WimPathAdd)opDict[s][0].Info;
-                                            if (firstInfo.OptimizeCompare(cmd.Info))
-                                                opDict[s].Add(cmd);
-                                            else
-                                                goto default;
-                                        }
-                                        else if (firstCmd.Type == CodeType.WimPathDelete)
-                                        {
-                                            CodeInfo_WimPathDelete firstInfo = (CodeInfo_WimPathDelete)opDict[s][0].Info;
-                                            if (firstInfo.OptimizeCompare(cmd.Info))
-                                                opDict[s].Add(cmd);
-                                            else
-                                                goto default;
-                                        }
-                                        else if (firstCmd.Type == CodeType.WimPathRename)
-                                        {
-                                            CodeInfo_WimPathRename firstInfo = (CodeInfo_WimPathRename)opDict[s][0].Info;
-                                            if (firstInfo.OptimizeCompare(cmd.Info))
-                                                opDict[s].Add(cmd);
-                                            else
-                                                goto default;
-                                        }
-                                        break;
-                                    }
-                                case CodeType.Comment: // Remove comments
-                                    break;
-                                default: // Optimize them
-                                    FinalizeSequence(s, opDict[s]);
-                                    s = CodeType.None;
-                                    loopAgain = true;
-                                    break;
-                            }
-                            break;
-                        #endregion
-                        #region Error
-                        default:
-                            throw new InternalException("Internal Logic Error at CodeOptimizer.InternalOptimize()");
-                            #endregion
-                    }
-                }
-                while (loopAgain);
-            }
-
-            #region Finish
-            foreach (var kv in opDict)
-                FinalizeSequence(kv.Key, kv.Value);
-            #endregion
-
-            #region FinalizeSequence
-            void FinalizeSequence(CodeType state, List<CodeCommand> cmdSeq)
-            {
-                CodeCommand opCmd;
-                if (cmdSeq.Count == 1)
-                    opCmd = cmdSeq[0];
-                else if (1 < cmdSeq.Count)
-                    opCmd = PackCommand(state, new List<CodeCommand>(cmdSeq));
-                else // if (cmds.Count <= 0)
-                    return;
-
-                Debug.Assert(opCmd != null, "Internal Logic Error in CodeOptimizer.Optimize");
-                optimized.Add(opCmd);
-
-                cmdSeq.Clear();
-            }
-            #endregion
-
-            return optimized;
-        }
         #endregion
 
         #region PackCommand
@@ -638,5 +153,186 @@ namespace PEBakery.Core
             return b.ToString();
         }
         #endregion
+
+        //---- Next-Gen Optimizer
+
+        #region OptimizeNext
+        public static void Optimize(List<CodeCommand> rootBlock)
+        {
+            Queue<List<CodeCommand>> blockQueue = new Queue<List<CodeCommand>>();
+            blockQueue.Enqueue(rootBlock);
+
+            while (0 < blockQueue.Count)
+            {
+                List<CodeCommand> block = blockQueue.Dequeue();
+
+                // Enqueue embedded codeblocks
+                foreach (CodeCommand cmd in block)
+                {
+                    if (cmd.Info is CodeEmbedInfo eInfo)
+                        blockQueue.Enqueue(eInfo.Link);
+                }
+
+                // [Pass 1] Group commands which can be possibly optimized
+                List<OptRange> optimizableGroups = GroupOptimizableCommands(block);
+
+                // [Pass 2] Perform variable dependency analysis, and break groups which has a dependency to each other.
+                List<OptRange> optimizedGroups = VariableDependencyAnalysis(block, optimizableGroups);
+
+                // [Pass 3] Optimize commands following optimizedGroups
+                List<CodeCommand> optBlock = CompactCommands(block, optimizedGroups);
+                block.Clear();
+                block.AddRange(optBlock);
+            }
+        }
+
+        private static CodeType[] WimCodeTypeOp { get; } = new CodeType[] { CodeType.WimPathAdd, CodeType.WimPathDelete, CodeType.WimPathRename };
+        private static List<OptRange> GroupOptimizableCommands(List<CodeCommand> block)
+        {
+            List<OptRange> optimizableGroups = new List<OptRange>();
+
+            if (block.Count == 0)
+                return optimizableGroups;
+
+            for (int x = 0; x < block.Count; x++)
+            {
+                CodeCommand lastCmd = block[x];
+
+                // Is next command optimizable? If yes, try again on next-next command.
+                int optBlockEnd = -1;
+                for (int y = x + 1; y < block.Count; y++)
+                {
+                    CodeCommand nextCmd = block[y];
+
+                    if (lastCmd.Type != nextCmd.Type)
+                    {
+                        if (!(WimCodeTypeOp.Contains(lastCmd.Type) && WimCodeTypeOp.Contains(nextCmd.Type)))
+                            break;
+                    }
+
+                    if (lastCmd.Info.IsOptimizable(nextCmd.Info))
+                        optBlockEnd = y;
+                    else
+                        break;
+                }
+
+                if (optBlockEnd != -1) // Not Found
+                {
+                    optimizableGroups.Add(new OptRange(lastCmd.Type, x, optBlockEnd + 1));
+                    x = optBlockEnd + 1;
+                }
+            }
+
+            return optimizableGroups;
+        }
+
+        private static List<OptRange> VariableDependencyAnalysis(List<CodeCommand> block, List<OptRange> optimizableRange)
+        {
+            List<OptRange> optimizedGroups = new List<OptRange>();
+
+            foreach (OptRange optRange in optimizableRange)
+            {
+                CodeCommand lastCmd = block[optRange.Begin];
+
+                HashSet<string> blockOutVars = lastCmd.Info.OutVars();
+                int lastIdx = optRange.Begin;
+                for (int i = optRange.Begin; i < optRange.End; i++)
+                {
+                    if (lastIdx == i)
+                        continue;
+                        
+                    CodeCommand cmd = block[i];
+
+                    HashSet<string> inVars = cmd.Info.InVars();
+                    HashSet<string> outVars = cmd.Info.OutVars();
+
+                    if (0 < inVars.Intersect(blockOutVars).Count())
+                    { // Dependency exists between commands
+                        optimizedGroups.Add(new OptRange(optRange.CodeType, lastIdx, i));
+                        lastIdx = i;
+                        blockOutVars.Clear();
+                    }
+                    else
+                    { // No dependency
+                        blockOutVars.UnionWith(outVars);
+                    }
+                }
+
+                if (lastIdx + 1 < optRange.End)
+                {
+                    optimizedGroups.Add(new OptRange(optRange.CodeType, lastIdx, optRange.End));
+                }
+            }
+
+            return optimizedGroups;
+        }
+
+        private static List<CodeCommand> CompactCommands(List<CodeCommand> block, List<OptRange> optimizedRange)
+        {
+            if (optimizedRange.Count == 0)
+                return new List<CodeCommand>(block);
+
+            List<CodeCommand> optBlock = new List<CodeCommand>();
+
+            int i = 0;
+            while (i < block.Count)
+            {
+                CodeCommand cmd = block[i];
+
+                OptRange? detectedRange;
+                if (OptRange.IsIndexInRanges(optimizedRange, i, out detectedRange) && detectedRange != null)
+                {
+                    List<CodeCommand> cmdsToOpt = block.Skip(detectedRange.Begin).Take(detectedRange.Count).ToList();
+                    CodeCommand opCmd = PackCommand(detectedRange.CodeType, cmdsToOpt);
+                    optBlock.Add(opCmd);
+                    i += detectedRange.Count;
+                }
+                else
+                {
+                    optBlock.Add(cmd);
+                    i += 1;
+                }
+            }
+
+            return optBlock;
+        }
+        #endregion
+
+        class OptRange
+        {
+            public CodeType CodeType { get; set; }
+            public int Begin { get; set; }
+            public int End { get; set; }
+            public int Count => End - Begin;
+
+            public OptRange(CodeType codeType, int begin, int end)
+            {
+                CodeType = codeType;
+                Begin = begin;
+                End = end;
+            }
+
+            public bool IsIndexInRanges(int idx)
+            {
+                return Begin <= idx && idx < End;
+            }
+
+            public static bool IsIndexInRanges(IEnumerable<OptRange> optRanges, int idx, out OptRange? outRange)
+            {
+                // 1 < x.Count was added to skip 1-count Range.
+                OptRange? optRange = optRanges.FirstOrDefault(x => 1 < x.Count && x.IsIndexInRanges(idx));
+                if (optRange != null)
+                {
+                    outRange = optRange;
+                    return true;
+                }
+                outRange = null;
+                return false;
+            }
+
+            public override string ToString() => $"OptRange({Begin}, {End})";
+        }
     }
+
+    
 }

--- a/PEBakery.Core/CodeParser.cs
+++ b/PEBakery.Core/CodeParser.cs
@@ -4591,6 +4591,33 @@ namespace PEBakery.Core
                    sectionReturnValueMatch;
         }
 
+        private static readonly string[] SpecialSharpVars = new string[] { "#c", "#a", "#oa", "#r" };
+        public static HashSet<string> DetectStringVariableReference(string str)
+        {
+            HashSet<string> refSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            MatchCollection matches = Regex.Matches(str, Variables.VarKeyRegexContainsVariable, RegexOptions.Compiled | RegexOptions.CultureInvariant); // ABC%Joveler%
+            if (0 < matches.Count)
+                refSet.Add(matches[0].Value);
+
+            matches = Regex.Matches(str, Variables.VarKeyRegexContainsSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #1
+            if (0 < matches.Count)
+                refSet.Add(matches[0].Value);
+
+            matches = Regex.Matches(str, Variables.VarKeyRegexContainsSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #o1
+            if (0 < matches.Count)
+                refSet.Add(matches[0].Value);
+
+            // #c, #a, #oa, #r
+            foreach (string specialSharpVar in SpecialSharpVars)
+            {
+                if (str.IndexOf(specialSharpVar, StringComparison.OrdinalIgnoreCase) != -1)
+                    refSet.Add(specialSharpVar);
+            }
+
+            return refSet;
+        }
+
         public CodeCommand ForgeControlEmbedCommand(string rawCode, List<string> args, int lineIdx)
         {
             CodeCommand embed = ParseStatementFromSlicedArgs(rawCode, args, lineIdx);

--- a/PEBakery.Core/CodeParser.cs
+++ b/PEBakery.Core/CodeParser.cs
@@ -157,7 +157,7 @@ namespace PEBakery.Core
             }
 
             if (_opts.OptimizeCode)
-                foldedList = CodeOptimizer.Optimize(foldedList);
+                CodeOptimizer.Optimize(foldedList);
 
             return (foldedList.ToArray(), errLogs);
         }
@@ -4781,7 +4781,7 @@ namespace PEBakery.Core
                             nestDepth++;
                             break;
                         }
-                        
+
                         break;
                     }
                 }

--- a/PEBakery.Core/Commands/CommandBranch.cs
+++ b/PEBakery.Core/Commands/CommandBranch.cs
@@ -383,7 +383,7 @@ namespace PEBakery.Core.Commands
             }
         }
 
-        
+
 
         public static void While(EngineState s, CodeCommand cmd)
         {
@@ -1344,7 +1344,7 @@ namespace PEBakery.Core.Commands
                         else
                         {
                             MessageBoxResult result = SystemHelper.MessageBoxDispatcherShow(s.OwnerWindow, message, "Confirm", MessageBoxButton.YesNo, MessageBoxImage.Question);
-                                
+
                             switch (result)
                             {
                                 case MessageBoxResult.Yes:

--- a/PEBakery.Core/Commands/CommandIni.cs
+++ b/PEBakery.Core/Commands/CommandIni.cs
@@ -91,9 +91,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_IniReadOp infoOp = (CodeInfo_IniReadOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_IniRead[] optInfos = infoOp.Infos<CodeInfo_IniRead>().ToArray();
 
-            string fileName = StringEscaper.Preprocess(s, infoOp.Infos[0].FileName);
+            string fileName = StringEscaper.Preprocess(s, optInfos[0].FileName);
             Debug.Assert(fileName != null, $"{nameof(fileName)} != null");
 
             if (!StringEscaper.PathSecurityCheck(fileName, out string errorMsg))
@@ -102,7 +103,7 @@ namespace PEBakery.Core.Commands
             IniKey[] keys = new IniKey[infoOp.Cmds.Count];
             for (int i = 0; i < keys.Length; i++)
             {
-                CodeInfo_IniRead info = infoOp.Infos[i];
+                CodeInfo_IniRead info = optInfos[i];
 
                 string sectionName = StringEscaper.Preprocess(s, info.Section);
                 string key = StringEscaper.Preprocess(s, info.Key);
@@ -122,7 +123,7 @@ namespace PEBakery.Core.Commands
             {
                 IniKey kv = keys[i];
                 CodeCommand subCmd = infoOp.Cmds[i];
-                CodeInfo_IniRead subInfo = infoOp.Infos[i];
+                CodeInfo_IniRead subInfo = optInfos[i];
 
                 if (kv.Value != null)
                 {
@@ -139,7 +140,7 @@ namespace PEBakery.Core.Commands
                 {
                     if (subInfo.DefaultValue != null)
                     {
-                        logs.Add(new LogInfo(LogState.Ignore, $"Key [{kv.Key}] does not exist. Assigning default value [{infoOp.Infos[i].DefaultValue}]"));
+                        logs.Add(new LogInfo(LogState.Ignore, $"Key [{kv.Key}] does not exist. Assigning default value [{optInfos[i].DefaultValue}]"));
 
                         List<LogInfo> varLogs = Variables.SetVariable(s, subInfo.DestVar, subInfo.DefaultValue, false, false, false);
                         logs.AddRange(varLogs);
@@ -206,9 +207,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_IniWriteOp infoOp = (CodeInfo_IniWriteOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_IniWrite[] optInfos = infoOp.Infos<CodeInfo_IniWrite>().ToArray();
 
-            string fileName = StringEscaper.Preprocess(s, infoOp.Infos[0].FileName);
+            string fileName = StringEscaper.Preprocess(s, optInfos[0].FileName);
 
             if (!StringEscaper.PathSecurityCheck(fileName, out string errorMsg))
                 return LogInfo.LogErrorMessage(logs, errorMsg);
@@ -216,7 +218,7 @@ namespace PEBakery.Core.Commands
             IniKey[] keys = new IniKey[infoOp.Cmds.Count];
             for (int i = 0; i < keys.Length; i++)
             {
-                CodeInfo_IniWrite info = infoOp.Infos[i];
+                CodeInfo_IniWrite info = optInfos[i];
 
                 string sectionName = StringEscaper.Preprocess(s, info.Section);
                 string key = StringEscaper.Preprocess(s, info.Key);
@@ -309,9 +311,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_IniDeleteOp infoOp = (CodeInfo_IniDeleteOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_IniDelete[] optInfos = infoOp.Infos<CodeInfo_IniDelete>().ToArray();
 
-            string fileName = StringEscaper.Preprocess(s, infoOp.Infos[0].FileName);
+            string fileName = StringEscaper.Preprocess(s, optInfos[0].FileName);
 
             if (!StringEscaper.PathSecurityCheck(fileName, out string errorMsg))
                 return LogInfo.LogErrorMessage(logs, errorMsg);
@@ -319,7 +322,7 @@ namespace PEBakery.Core.Commands
             IniKey[] keys = new IniKey[infoOp.Cmds.Count];
             for (int i = 0; i < keys.Length; i++)
             {
-                CodeInfo_IniDelete info = infoOp.Infos[i];
+                CodeInfo_IniDelete info = optInfos[i];
 
                 string sectionName = StringEscaper.Preprocess(s, info.Section);
                 string key = StringEscaper.Preprocess(s, info.Key);
@@ -413,16 +416,17 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_IniReadSectionOp infoOp = (CodeInfo_IniReadSectionOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_IniReadSection[] optInfos = infoOp.Infos<CodeInfo_IniReadSection>().ToArray();
 
-            string fileName = StringEscaper.Preprocess(s, infoOp.Infos[0].FileName);
+            string fileName = StringEscaper.Preprocess(s, optInfos[0].FileName);
 
             string[] sections = new string[infoOp.Cmds.Count];
             string[] destVars = new string[infoOp.Cmds.Count];
             string[] delims = new string[infoOp.Cmds.Count];
             for (int i = 0; i < sections.Length; i++)
             {
-                CodeInfo_IniReadSection info = infoOp.Infos[i];
+                CodeInfo_IniReadSection info = optInfos[i];
 
                 string section = StringEscaper.Preprocess(s, info.Section);
                 if (section.Length == 0)
@@ -518,9 +522,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_IniAddSectionOp infoOp = (CodeInfo_IniAddSectionOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_IniAddSection[] optInfos = infoOp.Infos<CodeInfo_IniAddSection>().ToArray();
 
-            string fileName = StringEscaper.Preprocess(s, infoOp.Infos[0].FileName);
+            string fileName = StringEscaper.Preprocess(s, optInfos[0].FileName);
 
             if (!StringEscaper.PathSecurityCheck(fileName, out string errorMsg))
                 return LogInfo.LogErrorMessage(logs, errorMsg);
@@ -528,7 +533,7 @@ namespace PEBakery.Core.Commands
             string[] sections = new string[infoOp.Cmds.Count];
             for (int i = 0; i < sections.Length; i++)
             {
-                CodeInfo_IniAddSection info = infoOp.Infos[i];
+                CodeInfo_IniAddSection info = optInfos[i];
 
                 string sectionName = StringEscaper.Preprocess(s, info.Section);
                 if (sectionName.Length == 0)
@@ -594,9 +599,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_IniDeleteSectionOp infoOp = (CodeInfo_IniDeleteSectionOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_IniDeleteSection[] optInfos = infoOp.Infos<CodeInfo_IniDeleteSection>().ToArray();
 
-            string fileName = StringEscaper.Preprocess(s, infoOp.Infos[0].FileName);
+            string fileName = StringEscaper.Preprocess(s, optInfos[0].FileName);
 
             if (!StringEscaper.PathSecurityCheck(fileName, out string errorMsg))
                 return LogInfo.LogErrorMessage(logs, errorMsg);
@@ -604,7 +610,7 @@ namespace PEBakery.Core.Commands
             string[] sections = new string[infoOp.Cmds.Count];
             for (int i = 0; i < sections.Length; i++)
             {
-                CodeInfo_IniDeleteSection info = infoOp.Infos[i];
+                CodeInfo_IniDeleteSection info = optInfos[i];
 
                 string sectionName = StringEscaper.Preprocess(s, info.Section); // WB082 : 여기 값은 변수 Expand 안한다.
                 if (sectionName.Length == 0)
@@ -673,17 +679,18 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_IniWriteTextLineOp infoOp = (CodeInfo_IniWriteTextLineOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_IniWriteTextLine[] optInfos = infoOp.Infos<CodeInfo_IniWriteTextLine>().ToArray();
 
-            string fileName = StringEscaper.Preprocess(s, infoOp.Infos[0].FileName);
+            string fileName = StringEscaper.Preprocess(s, optInfos[0].FileName);
 
-            bool append = infoOp.Infos[0].Append;
+            bool append = optInfos[0].Append;
 
             if (!StringEscaper.PathSecurityCheck(fileName, out string errorMsg))
                 return LogInfo.LogErrorMessage(logs, errorMsg);
 
-            List<IniKey> keyList = new List<IniKey>(infoOp.Infos.Count);
-            foreach (CodeInfo_IniWriteTextLine info in infoOp.Infos)
+            List<IniKey> keyList = new List<IniKey>(optInfos.Length);
+            foreach (CodeInfo_IniWriteTextLine info in optInfos)
             {
                 string sectionName = StringEscaper.Preprocess(s, info.Section);
                 string line = StringEscaper.Preprocess(s, info.Line);

--- a/PEBakery.Core/Commands/CommandInterface.cs
+++ b/PEBakery.Core/Commands/CommandInterface.cs
@@ -106,7 +106,8 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>(8);
 
-            CodeInfo_VisibleOp infoOp = (CodeInfo_VisibleOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_Visible[] optInfos = infoOp.Infos<CodeInfo_Visible>().ToArray();
 
             // Refresh is required to simulate WinBuilder 082 behavior
             Script? sc = s.Project.RefreshScript(cmd.Section.Script, s);
@@ -561,9 +562,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_ReadInterfaceOp infoOp = (CodeInfo_ReadInterfaceOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_ReadInterface[] optInfos = infoOp.Infos<CodeInfo_ReadInterface>().ToArray();
 
-            CodeInfo_ReadInterface firstInfo = infoOp.Infos[0];
+            CodeInfo_ReadInterface firstInfo = optInfos[0];
             string scriptFile = StringEscaper.Preprocess(s, firstInfo.ScriptFile);
             string section = StringEscaper.Preprocess(s, firstInfo.Section);
 
@@ -1158,9 +1160,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_WriteInterfaceOp infoOp = (CodeInfo_WriteInterfaceOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_WriteInterface[] optInfos = infoOp.Infos<CodeInfo_WriteInterface>().ToArray();
 
-            CodeInfo_WriteInterface firstInfo = infoOp.Infos[0];
+            CodeInfo_WriteInterface firstInfo = optInfos[0];
             string scriptFile = StringEscaper.Preprocess(s, firstInfo.ScriptFile);
             string section = StringEscaper.Preprocess(s, firstInfo.Section);
 

--- a/PEBakery.Core/Commands/CommandList.cs
+++ b/PEBakery.Core/Commands/CommandList.cs
@@ -328,7 +328,7 @@ namespace PEBakery.Core.Commands
                         // start == end : empty list
                         List<string> list = new List<string>();
                         if (startVal < endVal)
-                        { 
+                        {
                             for (long i = startVal; i < endVal; i += stepVal)
                                 list.Add(i.ToString());
                         }
@@ -336,7 +336,7 @@ namespace PEBakery.Core.Commands
                         {
                             for (long i = startVal; endVal < i; i += stepVal)
                                 list.Add(i.ToString());
-                        }                        
+                        }
 
                         listStr = StringEscaper.PackListStr(list, delimiter);
                         List<LogInfo> varLogs = Variables.SetVariable(s, subInfo.ListVar, listStr);

--- a/PEBakery.Core/Commands/CommandMath.cs
+++ b/PEBakery.Core/Commands/CommandMath.cs
@@ -617,7 +617,7 @@ namespace PEBakery.Core.Commands
 
                         if (char.IsControl(ch) && MathInfo_FromChar.AllowedControlChars.All(x => x != ch))
                             return LogInfo.LogErrorMessage(logs, $"[{dest}] is a non-convertable control character");
-                        
+
                         logs.AddRange(Variables.SetVariable(s, subInfo.DestVar, dest));
                     }
                     break;

--- a/PEBakery.Core/Commands/CommandText.cs
+++ b/PEBakery.Core/Commands/CommandText.cs
@@ -116,9 +116,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>(8);
 
-            CodeInfo_TXTAddLineOp infoOp = (CodeInfo_TXTAddLineOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_TXTAddLine[] optInfos = infoOp.Infos<CodeInfo_TXTAddLine>().ToArray();
 
-            CodeInfo_TXTAddLine firstInfo = infoOp.Infos[0];
+            CodeInfo_TXTAddLine firstInfo = optInfos[0];
             string fileName = StringEscaper.Preprocess(s, firstInfo.FileName);
             string modeStr = StringEscaper.Preprocess(s, firstInfo.Mode);
             TXTAddLineMode mode;
@@ -135,7 +136,7 @@ namespace PEBakery.Core.Commands
             // Detect encoding of text. If text does not exists, create blank file (ANSI)
             Encoding encoding;
             if (File.Exists(fileName))
-                encoding = EncodingHelper.SmartDetectEncoding(fileName, infoOp.Infos.Select(x => x.Line));
+                encoding = EncodingHelper.SmartDetectEncoding(fileName, optInfos.Select(x => x.Line));
             else
                 encoding = EncodingHelper.DefaultAnsi;
 
@@ -147,7 +148,7 @@ namespace PEBakery.Core.Commands
                 using (StreamWriter w = new StreamWriter(tempPath, false, encoding))
                 {
                     StringBuilder b = new StringBuilder();
-                    List<CodeInfo_TXTAddLine> infos = infoOp.Infos;
+                    List<CodeInfo_TXTAddLine> infos = optInfos.ToList();
                     infos.Reverse();
                     foreach (CodeInfo_TXTAddLine subInfo in infos)
                         b.AppendLine(StringEscaper.Preprocess(s, subInfo.Line));
@@ -163,7 +164,7 @@ namespace PEBakery.Core.Commands
             else if (mode == TXTAddLineMode.Append)
             {
                 StringBuilder b = new StringBuilder();
-                foreach (CodeInfo_TXTAddLine subInfo in infoOp.Infos)
+                foreach (CodeInfo_TXTAddLine subInfo in optInfos)
                     b.AppendLine(StringEscaper.Preprocess(s, subInfo.Line));
 
                 linesToWrite = b.ToString();
@@ -254,9 +255,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>(8);
 
-            CodeInfo_TXTReplaceOp infoOp = (CodeInfo_TXTReplaceOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_TXTReplace[] optInfos = infoOp.Infos<CodeInfo_TXTReplace>().ToArray();
 
-            CodeInfo_TXTReplace firstInfo = infoOp.Infos[0];
+            CodeInfo_TXTReplace firstInfo = optInfos[0];
             string fileName = StringEscaper.Preprocess(s, firstInfo.FileName);
 
             if (!StringEscaper.PathSecurityCheck(fileName, out string errorMsg))
@@ -283,8 +285,8 @@ namespace PEBakery.Core.Commands
             {
                 encoding = EncodingHelper.SmartDetectEncoding(fileName, () =>
                 {
-                    return infoOp.Infos.All(x => EncodingHelper.IsActiveCodePageCompatible(x.OldStr)) &&
-                        infoOp.Infos.All(x => EncodingHelper.IsActiveCodePageCompatible(x.NewStr));
+                    return optInfos.All(x => EncodingHelper.IsActiveCodePageCompatible(x.OldStr)) &&
+                        optInfos.All(x => EncodingHelper.IsActiveCodePageCompatible(x.NewStr));
                 });
             }
             else
@@ -361,9 +363,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_TXTDelLineOp infoOp = (CodeInfo_TXTDelLineOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_TXTDelLine[] optInfos = infoOp.Infos<CodeInfo_TXTDelLine>().ToArray();
 
-            CodeInfo_TXTDelLine firstInfo = infoOp.Infos[0];
+            CodeInfo_TXTDelLine firstInfo = optInfos[0];
             string fileName = StringEscaper.Preprocess(s, firstInfo.FileName);
 
             if (!StringEscaper.PathSecurityCheck(fileName, out string errorMsg))

--- a/PEBakery.Core/Commands/CommandWim.cs
+++ b/PEBakery.Core/Commands/CommandWim.cs
@@ -654,9 +654,10 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_WimExtractOp infoOp = (CodeInfo_WimExtractOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
+            CodeInfo_WimExtract[] optInfos = infoOp.Infos<CodeInfo_WimExtract>().ToArray(); ;
 
-            CodeInfo_WimExtract firstInfo = infoOp.Infos[0];
+            CodeInfo_WimExtract firstInfo = optInfos[0];
             string srcWim = StringEscaper.Preprocess(s, firstInfo.SrcWim);
             string imageIndexStr = StringEscaper.Preprocess(s, firstInfo.ImageIndex);
             string destDir = StringEscaper.Preprocess(s, firstInfo.DestDir);
@@ -683,7 +684,7 @@ namespace PEBakery.Core.Commands
                 extractFlags |= ExtractFlags.NoAttributes;
 
             List<string> extractPaths = new List<string>(infoOp.Cmds.Count);
-            foreach (CodeInfo_WimExtract info in infoOp.Infos)
+            foreach (CodeInfo_WimExtract info in optInfos)
             {
                 string extractPath = StringEscaper.Preprocess(s, info.ExtractPath);
                 extractPaths.Add(extractPath);
@@ -1450,7 +1451,7 @@ namespace PEBakery.Core.Commands
         {
             List<LogInfo> logs = new List<LogInfo>();
 
-            CodeInfo_WimPathOp infoOp = (CodeInfo_WimPathOp)cmd.Info;
+            CodeOptInfo infoOp = (CodeOptInfo)cmd.Info;
 
             string wimFile;
             string imageIndexStr;

--- a/PEBakery.Core/Engine.cs
+++ b/PEBakery.Core/Engine.cs
@@ -457,7 +457,7 @@ namespace PEBakery.Core
             if (DisableSetLocal(s))
             {
                 // If SetLocal is implicitly disabled due to the halt flags, do not log the warning.
-                if (!s.HaltReturnFlags.CheckScriptHalt() && !s.HaltReturnFlags.CheckSectionReturn() )
+                if (!s.HaltReturnFlags.CheckScriptHalt() && !s.HaltReturnFlags.CheckSectionReturn())
                 {
                     int stackDepth = s.LocalVarsStateStack.Count + 1; // If SetLocal is disabled, SetLocalStack is decremented. 
                     s.Logger.BuildWrite(s, new LogInfo(LogState.Warning, $"Local variable isolation (depth {stackDepth}) implicitly disabled", s.PeekDepth));
@@ -1748,7 +1748,7 @@ namespace PEBakery.Core
     public class EngineLoopSyntaxState
     {
         public CodeType CodeType { get; }
-        
+
 
         public EngineLoopSyntaxState(CodeType codeType)
         {

--- a/PEBakery.Core/Logger.cs
+++ b/PEBakery.Core/Logger.cs
@@ -106,7 +106,7 @@ namespace PEBakery.Core
         System,
         Build
     }
-    
+
     public enum LogExportFormat
     {
         Text,

--- a/PEBakery.Core/ProjectCollection.cs
+++ b/PEBakery.Core/ProjectCollection.cs
@@ -262,7 +262,7 @@ namespace PEBakery.Core
                     // Projects\MyApps
                     // [Project Tree]
                     // %BaseDir%\{Compat,System}
-                    
+
                     // dirPath: %BaseDir%\MyApps
                     // realPath: %BaseDir%\MyApps\Compat\Test.script
 

--- a/PEBakery.Core/UIRenderer.cs
+++ b/PEBakery.Core/UIRenderer.cs
@@ -536,7 +536,7 @@ namespace PEBakery.Core
             Debug.Assert(uiCtrl.Type == UIControlType.CheckBox, $"Wrong UIControlType in [{nameof(CheckBox_Unchecked)}]");
             if (uiCtrl.Type != UIControlType.CheckBox)
                 return;
-            
+
             UIInfo_CheckBox info = (UIInfo_CheckBox)uiCtrl.Info;
 
             // Update value of a CheckBox control.

--- a/PEBakery.Core/ViewModels/MainViewModel.cs
+++ b/PEBakery.Core/ViewModels/MainViewModel.cs
@@ -27,7 +27,6 @@
 
 using MahApps.Metro.IconPacks;
 using PEBakery.Helper;
-using PEBakery.WPF.Controls;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/PEBakery.Core/WpfControls/TextViewDialog.xaml.cs
+++ b/PEBakery.Core/WpfControls/TextViewDialog.xaml.cs
@@ -110,7 +110,6 @@ namespace PEBakery.WPF.Controls
         /// </summary>
         public static void DispatcherShow(Window? owner, string title, string message, string viewText, PackIconMaterialKind icon = PackIconMaterialKind.None)
         {
-            MessageBoxResult result = MessageBoxResult.None;
             if (Application.Current?.Dispatcher != null)
             {
                 Application.Current?.Dispatcher?.Invoke(() =>

--- a/PEBakery.Ini/IniReadWriter.cs
+++ b/PEBakery.Ini/IniReadWriter.cs
@@ -25,7 +25,6 @@
 using PEBakery.Helper;
 using System;
 using System.Buffers;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -33,7 +32,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace PEBakery.Ini
 {
@@ -3211,21 +3209,21 @@ namespace PEBakery.Ini
 
     #region IniFile
     public sealed class IniFile
-        {
-            /// <summary>
-            /// Path of the .ini file.
-            /// </summary>
-            public string FilePath { get; set; }
-            /// <summary>
-            /// Key is section name, and value is a Dictionary of keys and value.
-            /// </summary>
-            public Dictionary<string, Dictionary<string, string>> Sections { get; set; }
+    {
+        /// <summary>
+        /// Path of the .ini file.
+        /// </summary>
+        public string FilePath { get; set; }
+        /// <summary>
+        /// Key is section name, and value is a Dictionary of keys and value.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, string>> Sections { get; set; }
 
-            public IniFile(string filePath)
-            {
-                FilePath = filePath;
-                Sections = IniReadWriter.ParseFileToDict(filePath);
-            }
+        public IniFile(string filePath)
+        {
+            FilePath = filePath;
+            Sections = IniReadWriter.ParseFileToDict(filePath);
         }
+    }
     #endregion
 }


### PR DESCRIPTION
## Summary

- Rewrote `CodeOptimizer` to detect data hazards.
- Resolves #179.

## Details

Old `CodeOptimizer` was quite crude, it could not detect data hazards like this:
```
(1) A = IniRead(C, B)
(2) D = IniRead(C, A)
// -> (1) and (2) cannot be grouped, since (2) depends on (1).
```

The rewritten `CodeOptimizer` now detects such cases and avoids grouping them into one command.

- Add `InVars()`, `OutVars()` to every command (`CodeInfo`).
  -  `InVars()` returns referenced variables, and `OutVars()` returns setted variables.
- `CodeOptimizer.VariableDependencyAnalysis()` calculates dependency between commands using `InVars()` and `OutVars()`.

