### PR TITLE
Refactor registry commands 

### DIFF
--- a/PEBakery.Core.Tests/Command/CommandRegistryTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandRegistryTests.cs
@@ -1,5 +1,5 @@
 ﻿/*
-    Copyright (C) 2017-2022 Hajin Jang
+    Copyright (C) 2017-2023 Hajin Jang
     Licensed under GPL 3.0
  
     PEBakery is free software: you can redistribute it and/or modify
@@ -127,52 +127,82 @@ namespace PEBakery.Core.Tests.Command
             {
                 // Success
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x0,{subKeyStr},None",
-                    Registry.CurrentUser, RegistryValueKind.None, subKeyStr, "None", null);
+                    RegistryHive.CurrentUser, RegistryValueKind.None, subKeyStr, "None", null);
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0,{subKeyStr},None",
+                    RegistryHive.CurrentUser, RegistryValueKind.None, subKeyStr, "None", null);
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,REG_NONE,{subKeyStr},None",
+                    RegistryHive.CurrentUser, RegistryValueKind.None, subKeyStr, "None", null);
+
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x1,{subKeyStr},String,SZ",
-                    Registry.CurrentUser, RegistryValueKind.String, subKeyStr, "String", "SZ");
+                    RegistryHive.CurrentUser, RegistryValueKind.String, subKeyStr, "String", "SZ");
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,1,{subKeyStr},String,SZ",
+                    RegistryHive.CurrentUser, RegistryValueKind.String, subKeyStr, "String", "SZ");
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,REG_SZ,{subKeyStr},String,SZ",
+                    RegistryHive.CurrentUser, RegistryValueKind.String, subKeyStr, "String", "SZ");
+
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x2,{subKeyStr},ExpandString,#$pSystemRoot#$p\System32\notepad.exe",
-                    Registry.CurrentUser, RegistryValueKind.ExpandString, subKeyStr, "ExpandString", @"%SystemRoot%\System32\notepad.exe");
+                    RegistryHive.CurrentUser, RegistryValueKind.ExpandString, subKeyStr, "ExpandString", @"%SystemRoot%\System32\notepad.exe");
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,2,{subKeyStr},ExpandString,#$pSystemRoot#$p\System32\notepad.exe",
+                    RegistryHive.CurrentUser, RegistryValueKind.ExpandString, subKeyStr, "ExpandString", @"%SystemRoot%\System32\notepad.exe");
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,REG_EXPAND_SZ,{subKeyStr},ExpandString,#$pSystemRoot#$p\System32\notepad.exe",
+                    RegistryHive.CurrentUser, RegistryValueKind.ExpandString, subKeyStr, "ExpandString", @"%SystemRoot%\System32\notepad.exe");
+
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x7,{subKeyStr},MultiString,1,2,3",
-                    Registry.CurrentUser, RegistryValueKind.MultiString, subKeyStr, "MultiString", new string[] { "1", "2", "3" });
+                    RegistryHive.CurrentUser, RegistryValueKind.MultiString, subKeyStr, "MultiString", new string[] { "1", "2", "3" });
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,7,{subKeyStr},MultiString,1,2,3",
+                    RegistryHive.CurrentUser, RegistryValueKind.MultiString, subKeyStr, "MultiString", new string[] { "1", "2", "3" });
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,REG_MULTI_SZ,{subKeyStr},MultiString,1,2,3",
+                    RegistryHive.CurrentUser, RegistryValueKind.MultiString, subKeyStr, "MultiString", new string[] { "1", "2", "3" });
+
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x3,{subKeyStr},Binary,00,01,02",
-                    Registry.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 00, 01, 02 });
+                    RegistryHive.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 00, 01, 02 });
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,3,{subKeyStr},Binary,00,01,02",
+                    RegistryHive.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 00, 01, 02 });
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,REG_BINARY,{subKeyStr},Binary,00,01,02",
+                    RegistryHive.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 00, 01, 02 });
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x3,{subKeyStr},Binary,""03,04""",
-                    Registry.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 03, 04 },
+                    RegistryHive.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 03, 04 },
                     null, ErrorCheck.Overwrite);
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x3,{subKeyStr},Binary,05,06,07,NOWARN",
-                    Registry.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 05, 06, 07 });
+                    RegistryHive.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 05, 06, 07 });
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x3,{subKeyStr},Binary,""08,09"",NOWARN",
-                    Registry.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 08, 09 });
+                    RegistryHive.CurrentUser, RegistryValueKind.Binary, subKeyStr, "Binary", new byte[] { 08, 09 });
+
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x4,{subKeyStr},DWORD,1234",
-                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u);
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u);
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,4,{subKeyStr},DWORD,1234",
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u);
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,REG_DWORD,{subKeyStr},DWORD,1234",
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u);
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x4,{subKeyStr},DWORD,-1",
-                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 4294967295u,
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 4294967295u,
                     null, ErrorCheck.Overwrite);
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x4,{subKeyStr},DWORD,4294967295",
-                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 4294967295u,
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 4294967295u,
                     null, ErrorCheck.Overwrite);
+
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0xB,{subKeyStr},QWORD,4294967296",
-                    Registry.CurrentUser, RegistryValueKind.QWord, subKeyStr, "QWORD", 4294967296ul);
+                    RegistryHive.CurrentUser, RegistryValueKind.QWord, subKeyStr, "QWORD", 4294967296ul);
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,11,{subKeyStr},QWORD,4294967296",
+                    RegistryHive.CurrentUser, RegistryValueKind.QWord, subKeyStr, "QWORD", 4294967296ul);
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,REG_QWORD,{subKeyStr},QWORD,4294967296",
+                    RegistryHive.CurrentUser, RegistryValueKind.QWord, subKeyStr, "QWORD", 4294967296ul);
 
                 // was RegWriteLegacy
-                s.Variables.SetValue(VarsType.Local, "Compat", "HKCU");
-                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,%Compat%,0x4,{subKeyStr},DWORD,1234",
-                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
+                WriteVarSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,#r,0x4,{subKeyStr},DWORD,1234", "HKCU",
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
                     new CompatOption { LegacyRegWrite = true });
-                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,%Compat%,0x4,{subKeyStr},DWORD,1234",
-                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u, 
+                WriteVarSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,#r,0x4,{subKeyStr},DWORD,1234", "HKCU",
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u, 
                     new CompatOption());
-                s.Variables.DeleteKey(VarsType.Local, "Compat");
 
                 // still is RegWriteLegacy
-                s.Variables.SetValue(VarsType.Local, "Compat", "0x4");
-                WriteSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,%Compat%,{subKeyStr},DWORD,1234",
-                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
+                WriteVarSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,#r,{subKeyStr},DWORD,1234", "0x4",
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
                     new CompatOption { LegacyRegWrite = true });
-                WriteSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,%Compat%,{subKeyStr},DWORD,1234",
-                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
+                WriteVarSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,#r,{subKeyStr},DWORD,1234", "0x4",
+                    RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
                     new CompatOption(), ErrorCheck.ParserError);
-                s.Variables.DeleteKey(VarsType.Local, "Compat");
 
 
                 // Error
@@ -199,16 +229,16 @@ namespace PEBakery.Core.Tests.Command
             {
                 // Success
                 WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,HKCU,0x200000,{subKeyStr},Extra,00,01,02",
-                    Registry.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 00, 01, 02 });
+                    RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 00, 01, 02 });
                 WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,HKCU,0x100000,{subKeyStr},Extra,""03,04""",
-                    Registry.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 03, 04 },
+                    RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 03, 04 },
                     null, ErrorCheck.Overwrite);
                 WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,HKCU,0xFFff0009,{subKeyStr},Extra,05,06,07,NOWARN",
-                    Registry.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 05, 06, 07 });
+                    RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 05, 06, 07 });
                 WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,HKCU,0xffFF100d,{subKeyStr},Extra,""08,09"",NOWARN",
-                    Registry.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 08, 09 });
+                    RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 08, 09 });
                 WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,HKCU,0xFFff2012,{subKeyStr},Extra,,NOWARN",
-                    Registry.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", Array.Empty<byte>());
+                    RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", Array.Empty<byte>());
 
                 // Error
                 WriteErrorTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x200000,{subKeyStr},Extra,00,01,02", ErrorCheck.ParserError);
@@ -729,8 +759,24 @@ namespace PEBakery.Core.Tests.Command
             ReadTemplate(s, type, rawCode, compStr, check);
         }
 
+        private static void WriteVarSuccessTemplate(EngineState s, CodeType codeType, string rawCode, string varVal,
+                RegistryHive hive, RegistryValueKind compKind, string keyPath, string valueName, object? expect,
+                CompatOption? opts = null, ErrorCheck check = ErrorCheck.Success)
+        {
+            string valBak = s.ReturnValue;
+            try
+            {
+                s.ReturnValue = varVal;
+                WriteSuccessTemplate(s, codeType, rawCode, hive, compKind, keyPath, valueName, expect, opts, check);
+            }
+            finally
+            {
+                s.ReturnValue = valBak;
+            }
+        }
+
         private static void WriteSuccessTemplate(EngineState s, CodeType codeType, string rawCode,
-                RegistryKey hKey, RegistryValueKind compKind, string keyPath, string valueName, object? expect,
+                RegistryHive hive, RegistryValueKind compKind, string keyPath, string valueName, object? expect,
                 CompatOption? opts = null, ErrorCheck check = ErrorCheck.Success)
         {
             if (opts == null)
@@ -740,7 +786,8 @@ namespace PEBakery.Core.Tests.Command
 
             if (check == ErrorCheck.Success || check == ErrorCheck.Warning || check == ErrorCheck.Overwrite)
             {
-                using (RegistryKey? subKey = hKey.OpenSubKey(keyPath, false))
+                using (RegistryKey rootKey = RegistryKey.OpenBaseKey(hive, RegistryView.Registry64))
+                using (RegistryKey? subKey = rootKey.OpenSubKey(keyPath, false))
                 {
                     Assert.IsNotNull(subKey);
 
@@ -749,7 +796,7 @@ namespace PEBakery.Core.Tests.Command
 
                     object? valueData;
                     if (kind == RegistryValueKind.Unknown)
-                        valueData = RegistryHelper.RegGetValue(hKey, keyPath, valueName, RegistryValueKind.Unknown);
+                        valueData = RegistryHelper.RegGetValue(rootKey, keyPath, valueName, RegistryValueKind.Unknown);
                     else
                         valueData = subKey.GetValue(valueName, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
                     Assert.IsNotNull(valueData);
@@ -799,7 +846,7 @@ namespace PEBakery.Core.Tests.Command
                                 Assert.IsNotNull(expect);
                                 uint destInt = (uint)(int)valueData;
                                 uint compInt = (uint)expect;
-                                Assert.IsTrue(destInt == compInt);
+                                Assert.AreEqual(compInt, destInt);
                             }
                             break;
                         case RegistryValueKind.QWord:
@@ -807,7 +854,7 @@ namespace PEBakery.Core.Tests.Command
                                 Assert.IsNotNull(expect);
                                 ulong destInt = (ulong)(long)valueData;
                                 ulong compInt = (ulong)expect;
-                                Assert.IsTrue(destInt == compInt);
+                                Assert.AreEqual(compInt, destInt);
                             }
                             break;
                         default:

--- a/PEBakery.Core.Tests/Command/CommandRegistryTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandRegistryTests.cs
@@ -154,15 +154,26 @@ namespace PEBakery.Core.Tests.Command
                 WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0xB,{subKeyStr},QWORD,4294967296",
                     Registry.CurrentUser, RegistryValueKind.QWord, subKeyStr, "QWORD", 4294967296ul);
 
-                // RegWriteLegacy
+                // was RegWriteLegacy
                 s.Variables.SetValue(VarsType.Local, "Compat", "HKCU");
-                WriteSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,%Compat%,0x4,{subKeyStr},DWORD,1234",
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,%Compat%,0x4,{subKeyStr},DWORD,1234",
                     Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
                     new CompatOption { LegacyRegWrite = true });
-                WriteSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,%Compat%,0x4,{subKeyStr},DWORD,1234",
+                WriteSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,%Compat%,0x4,{subKeyStr},DWORD,1234",
+                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u, 
+                    new CompatOption());
+                s.Variables.DeleteKey(VarsType.Local, "Compat");
+
+                // still is RegWriteLegacy
+                s.Variables.SetValue(VarsType.Local, "Compat", "0x4");
+                WriteSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,%Compat%,{subKeyStr},DWORD,1234",
+                    Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
+                    new CompatOption { LegacyRegWrite = true });
+                WriteSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,%Compat%,{subKeyStr},DWORD,1234",
                     Registry.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
                     new CompatOption(), ErrorCheck.ParserError);
                 s.Variables.DeleteKey(VarsType.Local, "Compat");
+
 
                 // Error
                 WriteErrorTemplate(s, CodeType.RegWrite, $@"RegWrite,HKCU,0x4,{subKeyStr}", ErrorCheck.ParserError);

--- a/PEBakery.Core/CodeCommand.cs
+++ b/PEBakery.Core/CodeCommand.cs
@@ -646,8 +646,8 @@ namespace PEBakery.Core
     }
 
     public class CodeInfo_RegRead : CodeInfo
-    { // RegRead,<HKey>,<KeyPath>,<ValueName>,<%DestVar%>
-        public RegistryKey HKey { get; private set; }
+    { // RegRead,<KeyRoot>,<KeyPath>,<ValueName>,<%DestVar%>
+        public string KeyRoot { get; private set; }
         public string KeyPath { get; private set; }
         public string ValueName { get; private set; }
         public string DestVar { get; private set; }
@@ -655,9 +655,9 @@ namespace PEBakery.Core
         public override HashSet<string> InVars() => CreateInVars(KeyPath, ValueName);
         public override HashSet<string> OutVars() => CreateInVars(DestVar);
 
-        public CodeInfo_RegRead(RegistryKey hKey, string keyPath, string valueName, string destVar)
+        public CodeInfo_RegRead(string keyRoot, string keyPath, string valueName, string destVar)
         {
-            HKey = hKey;
+            KeyRoot = keyRoot;
             KeyPath = keyPath;
             ValueName = valueName;
             DestVar = destVar;
@@ -665,8 +665,7 @@ namespace PEBakery.Core
 
         public override string ToString()
         {
-            string? hKeyStr = RegistryHelper.RegKeyToString(HKey);
-            return $"{hKeyStr ?? "NULL"},{KeyPath},{ValueName},{DestVar}";
+            return $"{KeyRoot},{KeyPath},{ValueName},{DestVar}";
         }
     }
 
@@ -675,7 +674,7 @@ namespace PEBakery.Core
         // RegWrite,<HKey>,<ValueType>,<KeyPath>,<ValueName>,<ValueData | ValueDataList>,[NOWARN]
         // RegWriteEx,<HKey>,<ValueType>,<KeyPath>,<ValueName>,<ValueData | ValueDataList>,[NOWARN]
 
-        public RegistryKey HKey { get; private set; }
+        public string KeyRoot { get; private set; }
         public RegistryValueKind ValueType { get; private set; }
         public uint ValueTypeInt { get; private set; }
         public string KeyPath { get; private set; }
@@ -692,9 +691,9 @@ namespace PEBakery.Core
             return inVars;
         }
 
-        public CodeInfo_RegWrite(RegistryKey hKey, RegistryValueKind valueType, uint valueTypeInt, string keyPath, string? valueName, string? valueData, string[]? valueDataList, bool noWarn)
+        public CodeInfo_RegWrite(String keyRoot, RegistryValueKind valueType, uint valueTypeInt, string keyPath, string? valueName, string? valueData, string[]? valueDataList, bool noWarn)
         {
-            HKey = hKey;
+            KeyRoot = keyRoot;
             ValueType = valueType;
             ValueTypeInt = valueTypeInt;
             KeyPath = keyPath;
@@ -707,7 +706,7 @@ namespace PEBakery.Core
         public override string ToString()
         {
             StringBuilder b = new StringBuilder();
-            b.Append(RegistryHelper.RegKeyToString(HKey));
+            b.Append(KeyRoot);
             b.Append(",0x");
             b.Append(ValueTypeInt.ToString("X"));
             b.Append(',');

--- a/PEBakery.Core/CodeCommand.cs
+++ b/PEBakery.Core/CodeCommand.cs
@@ -691,7 +691,7 @@ namespace PEBakery.Core
             return inVars;
         }
 
-        public CodeInfo_RegWrite(String keyRoot, RegistryValueKind valueType, uint valueTypeInt, string keyPath, string? valueName, string? valueData, string[]? valueDataList, bool noWarn)
+        public CodeInfo_RegWrite(string keyRoot, RegistryValueKind valueType, uint valueTypeInt, string keyPath, string? valueName, string? valueData, string[]? valueDataList, bool noWarn)
         {
             KeyRoot = keyRoot;
             ValueType = valueType;
@@ -706,24 +706,27 @@ namespace PEBakery.Core
         public override string ToString()
         {
             StringBuilder b = new StringBuilder();
-            b.Append(KeyRoot);
+            b.Append(StringEscaper.QuoteEscape(KeyRoot));
             b.Append(",0x");
             b.Append(ValueTypeInt.ToString("X"));
             b.Append(',');
-            b.Append(KeyPath);
-            b.Append(',');
-            if (ValueDataList == null)
+            b.Append(StringEscaper.QuoteEscape(KeyPath));
+            if (ValueName != null)
             {
-                b.Append(ValueName);
                 b.Append(',');
+                b.Append(StringEscaper.QuoteEscape(ValueName));
             }
-            else
+            if (ValueData != null)
             {
-                for (int i = 0; i < ValueDataList.Length; i++)
+                b.Append(',');
+                b.Append(StringEscaper.QuoteEscape(ValueData));
+            }
+            if (ValueDataList != null)
+            {
+                foreach (string valueData in ValueDataList)
                 {
-                    b.Append(ValueDataList[i]);
-                    if (i + 1 < ValueDataList.Length)
-                        b.Append(',');
+                    b.Append(',');
+                    b.Append(StringEscaper.QuoteEscape(valueData));
                 }
             }
             if (NoWarn)
@@ -734,7 +737,7 @@ namespace PEBakery.Core
 
     public class CodeInfo_RegWriteLegacy : CodeInfo // Compatibility Shim for Win10PESE
     { // RegWrite,<HKey>,<ValueType>,<KeyPath>,<ValueName>,<ValueData | ValueDataList>
-        public string HKey { get; private set; }
+        public string KeyRoot { get; private set; }
         public string ValueType { get; private set; }
         public string KeyPath { get; private set; }
         public string? ValueName { get; private set; }
@@ -743,7 +746,7 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars()
         {
-            HashSet<string> inVars = CreateInVars(HKey, ValueType, KeyPath, ValueName);
+            HashSet<string> inVars = CreateInVars(KeyRoot, ValueType, KeyPath, ValueName);
             if (ValueDataList != null)
                 inVars.UnionWith(CreateInVars(ValueDataList));
             return inVars;
@@ -751,7 +754,7 @@ namespace PEBakery.Core
 
         public CodeInfo_RegWriteLegacy(string hKey, string valueType, string keyPath, string? valueName, string[]? valueDataList, bool noWarn)
         {
-            HKey = hKey;
+            KeyRoot = hKey;
             ValueType = valueType;
             KeyPath = keyPath;
             ValueName = valueName;
@@ -762,17 +765,17 @@ namespace PEBakery.Core
         public override string ToString()
         {
             StringBuilder b = new StringBuilder();
-            b.Append(HKey);
+            b.Append(StringEscaper.QuoteEscape(KeyRoot));
             b.Append(',');
-            b.Append(ValueType);
+            b.Append(StringEscaper.QuoteEscape(ValueType));
             b.Append(',');
-            b.Append(KeyPath);
+            b.Append(StringEscaper.QuoteEscape(KeyPath));
             if (ValueDataList != null)
             {
                 foreach (string valueData in ValueDataList)
                 {
                     b.Append(',');
-                    b.Append(valueData);
+                    b.Append(StringEscaper.QuoteEscape(valueData));
                 }
             }
             if (NoWarn)
@@ -783,15 +786,15 @@ namespace PEBakery.Core
 
     public class CodeInfo_RegDelete : CodeInfo
     { // RegDelete,<HKey>,<KeyPath>,[ValueName]
-        public RegistryKey HKey { get; private set; }
+        public string KeyRoot { get; private set; }
         public string KeyPath { get; private set; }
         public string? ValueName { get; private set; }
 
         public override HashSet<string> InVars() => CreateInVars(KeyPath, ValueName);
 
-        public CodeInfo_RegDelete(RegistryKey hKey, string keyPath, string? valueName = null)
+        public CodeInfo_RegDelete(string keyRoot, string keyPath, string? valueName = null)
         {
-            HKey = hKey;
+            KeyRoot = keyRoot;
             KeyPath = keyPath;
             ValueName = valueName;
         }
@@ -799,13 +802,13 @@ namespace PEBakery.Core
         public override string ToString()
         {
             StringBuilder b = new StringBuilder();
-            b.Append(RegistryHelper.RegKeyToString(HKey) ?? "NULL");
+            b.Append(StringEscaper.QuoteEscape(KeyRoot));
             b.Append(',');
-            b.Append(KeyPath);
+            b.Append(StringEscaper.QuoteEscape(KeyPath));
             if (ValueName != null)
             {
                 b.Append(',');
-                b.Append(ValueName);
+                b.Append(StringEscaper.QuoteEscape(ValueName));
             }
             return b.ToString();
         }
@@ -818,7 +821,7 @@ namespace PEBakery.Core
 
     public class CodeInfo_RegMulti : CodeInfo
     { // RegMulti,<HKey>,<KeyPath>,<ValueName>,<Type>,<Arg1>,[Arg2]
-        public RegistryKey HKey { get; private set; }
+        public string KeyRoot { get; private set; }
         public string KeyPath { get; private set; }
         public string ValueName { get; private set; }
         public RegMultiType ActionType { get; private set; }
@@ -827,9 +830,9 @@ namespace PEBakery.Core
 
         public override HashSet<string> InVars() => CreateInVars(KeyPath, ValueName, Arg1, Arg2);
 
-        public CodeInfo_RegMulti(RegistryKey hKey, string keyPath, string valueName, RegMultiType actionType, string arg1, string? arg2 = null)
+        public CodeInfo_RegMulti(string keyRoot, string keyPath, string valueName, RegMultiType actionType, string arg1, string? arg2 = null)
         {
-            HKey = hKey;
+            KeyRoot = keyRoot;
             KeyPath = keyPath;
             ValueName = valueName;
             ActionType = actionType;
@@ -839,10 +842,8 @@ namespace PEBakery.Core
 
         public override string ToString()
         {
-            string? HKeyStr = RegistryHelper.RegKeyToString(HKey);
-
             StringBuilder b = new StringBuilder();
-            b.Append(HKeyStr ?? "NULL");
+            b.Append(KeyRoot);
             b.Append(',');
             b.Append(KeyPath);
             b.Append(',');
@@ -877,50 +878,47 @@ namespace PEBakery.Core
 
     public class CodeInfo_RegExport : CodeInfo
     { // RegExport,<Key>,<RegFile>
-        public RegistryKey HKey { get; private set; }
+        public string KeyRoot { get; private set; }
         public string KeyPath { get; private set; }
         public string RegFile { get; private set; }
 
         public override HashSet<string> InVars() => CreateInVars(KeyPath, RegFile);
 
-        public CodeInfo_RegExport(RegistryKey hKey, string keyPath, string regFile)
+        public CodeInfo_RegExport(string keyRoot, string keyPath, string regFile)
         {
-            HKey = hKey;
+            KeyRoot = keyRoot;
             KeyPath = keyPath;
             RegFile = regFile;
         }
 
         public override string ToString()
         {
-            string? hKeyStr = RegistryHelper.RegKeyToString(HKey);
-            return $"{hKeyStr ?? "NULL"},{KeyPath},{RegFile}";
+            return $"{KeyRoot},{KeyPath},{RegFile}";
         }
     }
 
     public class CodeInfo_RegCopy : CodeInfo
     { // RegCopy,<SrcKey>,<SrcKeyPath>,<DestKey>,<DestKeyPath>,[WILDCARD]
-        public RegistryKey HSrcKey { get; private set; }
+        public string SrcKeyRoot { get; private set; }
         public string SrcKeyPath { get; private set; }
-        public RegistryKey HDestKey { get; private set; }
+        public string DestKeyRoot { get; private set; }
         public string DestKeyPath { get; private set; }
         public bool WildcardFlag { get; private set; }
 
         public override HashSet<string> InVars() => CreateInVars(SrcKeyPath, DestKeyPath);
 
-        public CodeInfo_RegCopy(RegistryKey hSrcKey, string srcKeyPath, RegistryKey hDestKey, string destKeyPath, bool wildcard)
+        public CodeInfo_RegCopy(string srcKeyRoot, string srcKeyPath, string destKeyRoot, string destKeyPath, bool wildcard)
         {
-            HSrcKey = hSrcKey;
+            SrcKeyRoot = srcKeyRoot;
             SrcKeyPath = srcKeyPath;
-            HDestKey = hDestKey;
+            DestKeyRoot = destKeyRoot;
             DestKeyPath = destKeyPath;
             WildcardFlag = wildcard;
         }
 
         public override string ToString()
         {
-            string? hKeySrcStr = RegistryHelper.RegKeyToString(HSrcKey);
-            string? hKeyDestStr = RegistryHelper.RegKeyToString(HDestKey);
-            return $"{hKeySrcStr ?? "NULL"},{SrcKeyPath},{hKeyDestStr ?? "NULL"},{DestKeyPath}{(WildcardFlag ? ",WILDCARD" : string.Empty)}";
+            return $"{SrcKeyRoot},{SrcKeyPath},{DestKeyRoot},{DestKeyPath}{(WildcardFlag ? ",WILDCARD" : string.Empty)}";
         }
     }
     #endregion

--- a/PEBakery.Core/CodeParser.cs
+++ b/PEBakery.Core/CodeParser.cs
@@ -29,7 +29,6 @@ using Microsoft.Win32;
 using PEBakery.Helper;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -815,16 +814,12 @@ namespace PEBakery.Core
                         if (CheckInfoArgumentCount(args, minArgCount, maxArgCount))
                             throw new InvalidCommandException($"Command [{type}] can have [{minArgCount}] ~ [{maxArgCount}] arguments", rawCode);
 
-                        RegistryKey? hKey = RegistryHelper.ParseStringToRegKey(args[0]);
-                        if (hKey == null)
-                            throw new InvalidCommandException($"Invalid HKEY [{args[0]}]", rawCode);
-
                         string keyPath = args[1];
                         string? valueName = null;
                         if (args.Count == maxArgCount)
                             valueName = args[2];
 
-                        return new CodeInfo_RegDelete(hKey, keyPath, valueName);
+                        return new CodeInfo_RegDelete(args[0], keyPath, valueName);
                     }
                 case CodeType.RegMulti:
                     { // RegMulti,<HKey>,<KeyPath>,<ValueName>,<Type>,<Arg1>,[Arg2]
@@ -832,10 +827,6 @@ namespace PEBakery.Core
                         const int maxArgCount = 6;
                         if (CheckInfoArgumentCount(args, minArgCount, maxArgCount))
                             throw new InvalidCommandException($"Command [{type}] can have [{minArgCount}] ~ [{maxArgCount}] arguments", rawCode);
-
-                        RegistryKey? hKey = RegistryHelper.ParseStringToRegKey(args[0]);
-                        if (hKey == null)
-                            throw new InvalidCommandException($"Invalid HKEY [{args[0]}]", rawCode);
 
                         string keyPath = args[1];
                         string valueName = args[2];
@@ -850,7 +841,7 @@ namespace PEBakery.Core
                         if (args.Count == maxArgCount)
                             arg2 = args[5];
 
-                        return new CodeInfo_RegMulti(hKey, keyPath, valueName, valType, arg1, arg2);
+                        return new CodeInfo_RegMulti(args[0], keyPath, valueName, valType, arg1, arg2);
                     }
                 case CodeType.RegImport:
                     { // RegImport,<RegFile>
@@ -866,11 +857,7 @@ namespace PEBakery.Core
                         if (args.Count != argCount)
                             throw new InvalidCommandException($"Command [{type}] must have [{argCount}] arguments", rawCode);
 
-                        RegistryKey? hKey = RegistryHelper.ParseStringToRegKey(args[0]);
-                        if (hKey == null)
-                            throw new InvalidCommandException($"Invalid HKEY [{args[0]}]", rawCode);
-
-                        return new CodeInfo_RegExport(hKey, args[1], args[2]);
+                        return new CodeInfo_RegExport(args[0], args[1], args[2]);
                     }
                 case CodeType.RegCopy:
                     { // RegCopy,<SrcKey>,<SrcKeyPath>,<DestKey>,<DestKeyPath>,[WILDCARD]
@@ -878,13 +865,6 @@ namespace PEBakery.Core
                         const int maxArgCount = 5;
                         if (CheckInfoArgumentCount(args, minArgCount, maxArgCount))
                             throw new InvalidCommandException($"Command [{type}] can have [{minArgCount}] ~ [{maxArgCount}] arguments", rawCode);
-
-                        RegistryKey? hSrcKey = RegistryHelper.ParseStringToRegKey(args[0]);
-                        if (hSrcKey == null)
-                            throw new InvalidCommandException($"Invalid HKEY [{args[0]}]", rawCode);
-                        RegistryKey? hDestKey = RegistryHelper.ParseStringToRegKey(args[2]);
-                        if (hDestKey == null)
-                            throw new InvalidCommandException($"Invalid HKEY [{args[2]}]", rawCode);
 
                         bool wildcard = false;
                         for (int i = minArgCount; i < args.Count; i++)
@@ -902,7 +882,7 @@ namespace PEBakery.Core
                             }
                         }
 
-                        return new CodeInfo_RegCopy(hSrcKey, args[1], hDestKey, args[3], wildcard);
+                        return new CodeInfo_RegCopy(args[0], args[1], args[2], args[3], wildcard);
                     }
                 #endregion
                 #region 03 Text

--- a/PEBakery.Core/Commands/CommandRegistry.cs
+++ b/PEBakery.Core/Commands/CommandRegistry.cs
@@ -129,14 +129,14 @@ namespace PEBakery.Core.Commands
                 { // Not an ordinary Registry value type -> Use Win32 API directly.
                     object? valueData = RegistryHelper.RegGetValue(rootKey, keyPath, valueName, RegistryValueKind.Unknown);
                     if (valueData is not byte[] bytes)
-                        return LogInfo.LogErrorMessage(logs, $"Cannot read registry key [{fullKeyPath}]");
+                        return LogInfo.LogErrorMessage(logs, $"Cannot read registry value [{fullKeyPath}\\{valueName}]");
                     valueDataStr = StringEscaper.PackRegBinary(bytes);
                 }
                 else
                 {
                     object? valueData = subKey.GetValue(valueName, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
                     if (valueData == null)
-                        return LogInfo.LogErrorMessage(logs, $"Cannot read registry key [{fullKeyPath}]");
+                        return LogInfo.LogErrorMessage(logs, $"Cannot read registry value [{fullKeyPath}\\{valueName}]");
 
                     switch (kind)
                     {
@@ -218,7 +218,7 @@ namespace PEBakery.Core.Commands
             {
                 if (valueName == null)
                 {
-                    logs.Add(new LogInfo(LogState.Success, $"Registry subkey [{fullKeyPath}] created"));
+                    logs.Add(new LogInfo(LogState.Success, $"Created registry subkey [{fullKeyPath}]"));
                     return logs;
                 }
 
@@ -231,7 +231,7 @@ namespace PEBakery.Core.Commands
                     case RegistryValueKind.Unknown:
                         { // RegWriteEx only - Not an ordinary Registry value type -> Use Win32 API directly.
                             if (cmd.Type != CodeType.RegWriteEx)
-                                throw new InternalException("[RegistryValueKind.Unknown] must be handled by [RegWriteEx], not [RegWrite]");
+                                throw new InternalException($"[RegistryValueKind.Unknown] must be handled by [{CodeType.RegWriteEx}], not [{CodeType.RegWrite}]. Check {nameof(CodeParser)}.");
 
                             (byte[]? binData, string valueData) = ParseByteArrayFromString();
                             if (binData == null)
@@ -328,18 +328,11 @@ namespace PEBakery.Core.Commands
 
         public static List<LogInfo> RegWriteLegacy(EngineState s, CodeCommand cmd)
         { // Compatibility Shim for WinBuilder 082
-            List<LogInfo> logs = new List<LogInfo>();
-
             CodeInfo_RegWriteLegacy info = (CodeInfo_RegWriteLegacy)cmd.Info;
-
-            string hKeyStr = StringEscaper.Preprocess(s, info.HKey);
-            RegistryKey? hKey = RegistryHelper.ParseStringToRegKey(hKeyStr);
-            if (hKey == null)
-                return LogInfo.LogErrorMessage(logs, $"Invalid HKey [{hKeyStr}]");
 
             string valTypeStr = StringEscaper.Preprocess(s, info.ValueType);
 
-            List<string> args = new List<string> { hKeyStr, valTypeStr, info.KeyPath };
+            List<string> args = new List<string> { info.KeyRoot, valTypeStr, info.KeyPath };
             if (info.ValueName != null)
                 args.Add(info.ValueName);
             if (info.ValueDataList != null)
@@ -360,46 +353,50 @@ namespace PEBakery.Core.Commands
 
             CodeInfo_RegDelete info = (CodeInfo_RegDelete)cmd.Info;
 
+            string keyRoot = StringEscaper.Preprocess(s, info.KeyRoot);
             string keyPath = StringEscaper.Preprocess(s, info.KeyPath);
 
-            string? hKeyStr = RegistryHelper.RegKeyToString(info.HKey);
-            if (hKeyStr == null)
-                throw new InternalException("Internal Logic Error");
+            if (RegistryHelper.ParseStringToRegHive(keyRoot) is not RegistryHive hiveKind)
+                return LogInfo.LogErrorMessage(logs, $"Registry hive [{keyRoot}] is not a valid hive");
+            string hKeyStr = RegistryHelper.RegHiveToString(hiveKind) ?? keyRoot;
 
             string fullKeyPath = $"{hKeyStr}\\{keyPath}";
 
-            if (info.ValueName == null)
-            { // Delete SubKey
-                try
-                {
-                    info.HKey.DeleteSubKeyTree(keyPath, true);
-                    logs.Add(new LogInfo(LogState.Success, $"Registry key [{fullKeyPath}] was deleted"));
-                }
-                catch (ArgumentException)
-                {
-                    logs.Add(new LogInfo(LogState.Warning, $"Registry key [{fullKeyPath}] does not exist"));
-                }
-            }
-            else
-            { // Delete Value
-                string valueName = StringEscaper.Preprocess(s, info.ValueName);
-
-                using (RegistryKey? subKey = info.HKey.OpenSubKey(keyPath, true))
-                {
-                    if (subKey == null)
-                    {
-                        logs.Add(new LogInfo(LogState.Warning, $"Registry key [{fullKeyPath}] does not exist"));
-                        return logs;
-                    }
-
+            using (RegistryKey rootKey = RegistryKey.OpenBaseKey(hiveKind, RegistryView.Registry64))
+            {
+                if (info.ValueName == null)
+                { // Delete SubKey
                     try
                     {
-                        subKey.DeleteValue(valueName, true);
-                        logs.Add(new LogInfo(LogState.Success, $"Registry value [{fullKeyPath}\\{valueName}] was deleted"));
+                        rootKey.DeleteSubKeyTree(keyPath, true);
+                        logs.Add(new LogInfo(LogState.Success, $"Registry key [{fullKeyPath}] was deleted"));
                     }
                     catch (ArgumentException)
                     {
-                        logs.Add(new LogInfo(LogState.Warning, $"Registry value [{fullKeyPath}\\{valueName}] does not exist"));
+                        logs.Add(new LogInfo(LogState.Warning, $"Registry key [{fullKeyPath}] does not exist"));
+                    }
+                }
+                else
+                { // Delete Value
+                    string valueName = StringEscaper.Preprocess(s, info.ValueName);
+
+                    using (RegistryKey? subKey = rootKey.OpenSubKey(keyPath, true))
+                    {
+                        if (subKey == null)
+                        {
+                            logs.Add(new LogInfo(LogState.Warning, $"Registry key [{fullKeyPath}] does not exist"));
+                            return logs;
+                        }
+
+                        try
+                        {
+                            subKey.DeleteValue(valueName, true);
+                            logs.Add(new LogInfo(LogState.Success, $"Registry value [{fullKeyPath}\\{valueName}] was deleted"));
+                        }
+                        catch (ArgumentException)
+                        {
+                            logs.Add(new LogInfo(LogState.Warning, $"Registry value [{fullKeyPath}\\{valueName}] does not exist"));
+                        }
                     }
                 }
             }
@@ -413,6 +410,7 @@ namespace PEBakery.Core.Commands
 
             CodeInfo_RegMulti info = (CodeInfo_RegMulti)cmd.Info;
 
+            string keyRoot = StringEscaper.Preprocess(s, info.KeyRoot);
             string keyPath = StringEscaper.Preprocess(s, info.KeyPath);
             string valueName = StringEscaper.Preprocess(s, info.ValueName);
             string arg1 = StringEscaper.Preprocess(s, info.Arg1);
@@ -420,12 +418,14 @@ namespace PEBakery.Core.Commands
             if (info.Arg2 != null)
                 arg2 = StringEscaper.Preprocess(s, info.Arg2);
 
-            string? hKeyStr = RegistryHelper.RegKeyToString(info.HKey);
-            if (hKeyStr == null)
-                throw new InternalException("Internal Logic Error");
+            if (RegistryHelper.ParseStringToRegHive(keyRoot) is not RegistryHive hiveKind)
+                return LogInfo.LogErrorMessage(logs, $"Registry hive [{keyRoot}] is not a valid hive");
+            string hKeyStr = RegistryHelper.RegHiveToString(hiveKind) ?? keyRoot;
+
             string fullKeyPath = $"{hKeyStr}\\{keyPath}";
 
-            using (RegistryKey? subKey = info.HKey.OpenSubKey(keyPath, true))
+            using (RegistryKey rootKey = RegistryKey.OpenBaseKey(hiveKind, RegistryView.Registry64))
+            using (RegistryKey? subKey = rootKey.OpenSubKey(keyPath, true))
             {
                 if (subKey == null)
                     return LogInfo.LogErrorMessage(logs, $"Registry key [{fullKeyPath}] does not exist");
@@ -602,9 +602,6 @@ namespace PEBakery.Core.Commands
 
             CodeInfo_RegImport info = (CodeInfo_RegImport)cmd.Info;
 
-            // Consider using RegRestoreKeyW
-            // https://docs.microsoft.com/en-us/windows/desktop/api/winreg/nf-winreg-regrestorekeyw
-
             string regFile = StringEscaper.Preprocess(s, info.RegFile);
 
             using (Process proc = new Process())
@@ -633,14 +630,16 @@ namespace PEBakery.Core.Commands
 
             CodeInfo_RegExport info = (CodeInfo_RegExport)cmd.Info;
 
+            string keyRoot = StringEscaper.Preprocess(s, info.KeyRoot);
             string keyPath = StringEscaper.Preprocess(s, info.KeyPath);
             string regFile = StringEscaper.Preprocess(s, info.RegFile);
 
-            // RegSaveKeyW saves key in the HIVE format, not .REG format
-            // .REG file format is baked in to reg.exe/regedit.exe, so no way to access it with APIl
-            string? hKeyStr = RegistryHelper.RegKeyToString(info.HKey);
-            if (hKeyStr == null)
-                throw new InternalException("Internal Logic Error at RegExport");
+            // RegSaveKeyW saves key in the HIVE format, not .REG format.
+            // .REG file format is baked in to reg.exe/regedit.exe, so we cannot directly call Win32 API.
+            if (RegistryHelper.ParseStringToRegHive(keyRoot) is not RegistryHive hiveKind)
+                return LogInfo.LogErrorMessage(logs, $"Registry hive [{keyRoot}] is not a valid hive");
+
+            string hKeyStr = RegistryHelper.RegHiveToString(hiveKind) ?? keyRoot;
             string fullKeyPath = $"{hKeyStr}\\{keyPath}";
 
             if (File.Exists(regFile))
@@ -672,49 +671,59 @@ namespace PEBakery.Core.Commands
 
             CodeInfo_RegCopy info = (CodeInfo_RegCopy)cmd.Info;
 
+            string srcKeyRoot = StringEscaper.Preprocess(s, info.SrcKeyRoot);
             string srcKeyPath = StringEscaper.Preprocess(s, info.SrcKeyPath);
+            string destKeyRoot = StringEscaper.Preprocess(s, info.DestKeyRoot);
             string destKeyPath = StringEscaper.Preprocess(s, info.DestKeyPath);
 
-            string? hSrcKeyStr = RegistryHelper.RegKeyToString(info.HSrcKey);
-            string? hDestKeyStr = RegistryHelper.RegKeyToString(info.HDestKey);
-            if (hSrcKeyStr == null)
-                return LogInfo.LogErrorMessage(logs, $"{info.HSrcKey} is null");
-            if (hDestKeyStr == null)
-                return LogInfo.LogErrorMessage(logs, $"{info.HDestKey} is null");
+            if (RegistryHelper.ParseStringToRegHive(srcKeyRoot) is not RegistryHive srcHiveKind)
+                return LogInfo.LogErrorMessage(logs, $"Source Registry hive [{srcKeyRoot}] is not a valid hive");
+            if (RegistryHelper.ParseStringToRegHive(destKeyRoot) is not RegistryHive destHiveKind)
+                return LogInfo.LogErrorMessage(logs, $"Destination Registry hive [{destKeyRoot}] is not a valid hive");
+
+            string hSrcKeyStr = RegistryHelper.RegHiveToString(srcHiveKind) ?? srcKeyRoot;
+            string hDestKeyStr = RegistryHelper.RegHiveToString(destHiveKind) ?? destKeyRoot;
+
             string fullSrcKeyPath = $"{hSrcKeyStr}\\{srcKeyPath}";
             string fullDestKeyPath = $"{hDestKeyStr}\\{destKeyPath}";
 
-            if (info.WildcardFlag)
+            using (RegistryKey srcRootKey = RegistryKey.OpenBaseKey(srcHiveKind, RegistryView.Registry64))
+            using (RegistryKey destRootKey = RegistryKey.OpenBaseKey(destHiveKind, RegistryView.Registry64))
             {
-                string wildcard = Path.GetFileName(srcKeyPath);
-                if (wildcard.IndexOfAny(new[] { '*', '?' }) == -1)
-                    return LogInfo.LogErrorMessage(logs, $"SrcKeyPath [{srcKeyPath}] does not contain wildcard");
-
-                string? srcKeyParentPath = Path.GetDirectoryName(srcKeyPath);
-                if (srcKeyParentPath == null)
-                    return LogInfo.LogErrorMessage(logs, $"Invalid {nameof(info.SrcKeyPath)} [{srcKeyPath}]");
-
-                using (RegistryKey? parentSubKey = info.HSrcKey.OpenSubKey(srcKeyParentPath, false))
+                if (info.WildcardFlag)
                 {
-                    if (parentSubKey == null)
-                        return LogInfo.LogErrorMessage(logs, $"Registry key [{srcKeyPath}] does not exist");
+                    string wildcard = Path.GetFileName(srcKeyPath);
+                    if (wildcard.IndexOfAny(new[] { '*', '?' }) == -1)
+                        return LogInfo.LogErrorMessage(logs, $"SrcKeyPath [{srcKeyPath}] does not contain wildcard");
 
-                    foreach (string targetSubKey in StringHelper.MatchGlob(wildcard, parentSubKey.GetSubKeyNames(), StringComparison.OrdinalIgnoreCase))
+                    string? srcKeyParentPath = Path.GetDirectoryName(srcKeyPath);
+                    if (srcKeyParentPath == null)
+                        return LogInfo.LogErrorMessage(logs, $"Invalid {nameof(info.SrcKeyPath)} [{srcKeyPath}]");
+
+                    using (RegistryKey? parentSubKey = srcRootKey.OpenSubKey(srcKeyParentPath, false))
                     {
-                        string copySrcSubKeyPath = Path.Combine(srcKeyParentPath, targetSubKey);
-                        string copyDestSubKeyPath = Path.Combine(destKeyPath, targetSubKey);
-                        RegistryHelper.CopySubKey(info.HSrcKey, copySrcSubKeyPath, info.HDestKey, copyDestSubKeyPath);
+                        if (parentSubKey == null)
+                            return LogInfo.LogErrorMessage(logs, $"Registry key [{srcKeyPath}] does not exist");
+
+                        foreach (string targetSubKey in StringHelper.MatchGlob(wildcard, parentSubKey.GetSubKeyNames(), StringComparison.OrdinalIgnoreCase))
+                        {
+                            string copySrcSubKeyPath = Path.Combine(srcKeyParentPath, targetSubKey);
+                            string copyDestSubKeyPath = Path.Combine(destKeyPath, targetSubKey);
+                            RegistryHelper.CopySubKey(srcRootKey, copySrcSubKeyPath, destRootKey, copyDestSubKeyPath);
+                        }
                     }
+
+                    logs.Add(new LogInfo(LogState.Success, $"Registry key [{fullSrcKeyPath}] copied to [{fullDestKeyPath}]"));
                 }
+                else
+                { // No Wildcard
+                    RegistryHelper.CopySubKey(srcRootKey, srcKeyPath, destRootKey, destKeyPath);
 
-                logs.Add(new LogInfo(LogState.Success, $"Registry key [{fullSrcKeyPath}] copied to [{fullDestKeyPath}]"));
+                    logs.Add(new LogInfo(LogState.Success, $"Registry key [{fullSrcKeyPath}] copied to [{fullDestKeyPath}]"));
+                }
             }
-            else
-            { // No Wildcard
-                RegistryHelper.CopySubKey(info.HSrcKey, srcKeyPath, info.HDestKey, destKeyPath);
 
-                logs.Add(new LogInfo(LogState.Success, $"Registry key [{fullSrcKeyPath}] copied to [{fullDestKeyPath}]"));
-            }
+            
 
             return logs;
         }

--- a/PEBakery.Helper/RegistryHelper.cs
+++ b/PEBakery.Helper/RegistryHelper.cs
@@ -26,6 +26,7 @@
 using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -230,6 +231,57 @@ namespace PEBakery.Helper
             else
                 hKey = new SafeRegistryHandle(IntPtr.Zero, true);
             return hKey;
+        }
+
+        public static RegistryValueKind? ParseValueKind(string str)
+        {
+            if (str.Equals("REG_BINARY", StringComparison.OrdinalIgnoreCase))
+                return RegistryValueKind.Binary;
+            else if (str.Equals("REG_DWORD", StringComparison.OrdinalIgnoreCase))
+                return RegistryValueKind.DWord;
+            else if (str.Equals("REG_EXPAND_SZ", StringComparison.OrdinalIgnoreCase))
+                return RegistryValueKind.ExpandString;
+            else if (str.Equals("REG_MULTI_SZ", StringComparison.OrdinalIgnoreCase))
+                return RegistryValueKind.MultiString;
+            else if (str.Equals("REG_NONE", StringComparison.OrdinalIgnoreCase))
+                return RegistryValueKind.None;
+            else if (str.Equals("REG_QWORD", StringComparison.OrdinalIgnoreCase))
+                return RegistryValueKind.QWord;
+            else if (str.Equals("REG_SZ", StringComparison.OrdinalIgnoreCase))
+                return RegistryValueKind.String;
+            return null;
+        }
+
+        /// <summary>
+        /// The dictionary to map RegistryValueKidn to WBInt values.
+        /// WBInt value does not exactly map to RegistryValueKind, so maunal conversion is necessary.
+        /// </summary>
+        private static readonly Dictionary<RegistryValueKind, uint> ValueKindWBIntDict = new Dictionary<RegistryValueKind, uint>()
+        {
+            [RegistryValueKind.None] = 0,
+            [RegistryValueKind.String] = 1,
+            [RegistryValueKind.ExpandString] = 2,
+            [RegistryValueKind.Binary] = 3,
+            [RegistryValueKind.DWord] = 4,
+            [RegistryValueKind.MultiString] = 7,
+            [RegistryValueKind.QWord] = 11,
+        };
+
+        public static uint? ValueKindToWBInt(RegistryValueKind valueType)
+        {
+            if (ValueKindWBIntDict.ContainsKey(valueType))
+                return ValueKindWBIntDict[valueType];    
+            return null;
+        }
+
+        public static RegistryValueKind? WBIntToValudKind(uint wbInt)
+        {
+            foreach (var kv in ValueKindWBIntDict)
+            {
+                if (kv.Value == wbInt)
+                    return kv.Key;
+            }
+            return null;
         }
         #endregion
 

--- a/PEBakery.Helper/RegistryHelper.cs
+++ b/PEBakery.Helper/RegistryHelper.cs
@@ -104,6 +104,30 @@ namespace PEBakery.Helper
 
         #region Parse
         [SupportedOSPlatform("windows")]
+        public static RegistryHive? ParseStringToRegHive(string rootKey)
+        {
+            RegistryHive? regHive;
+            if (rootKey.Equals("HKCR", StringComparison.OrdinalIgnoreCase) ||
+                rootKey.Equals("HKEY_CLASSES_ROOT", StringComparison.OrdinalIgnoreCase))
+                regHive = RegistryHive.ClassesRoot; // HKEY_CLASSES_ROOT
+            else if (rootKey.Equals("HKCU", StringComparison.OrdinalIgnoreCase) ||
+                rootKey.Equals("HKEY_CURRENT_USER", StringComparison.OrdinalIgnoreCase))
+                regHive = RegistryHive.CurrentUser; // HKEY_CURRENT_USER
+            else if (rootKey.Equals("HKLM", StringComparison.OrdinalIgnoreCase) ||
+                rootKey.Equals("HKEY_LOCAL_MACHINE", StringComparison.OrdinalIgnoreCase))
+                regHive = RegistryHive.LocalMachine; // HKEY_LOCAL_MACHINE
+            else if (rootKey.Equals("HKU", StringComparison.OrdinalIgnoreCase) ||
+                rootKey.Equals("HKEY_USERS", StringComparison.OrdinalIgnoreCase))
+                regHive = RegistryHive.Users; // HKEY_USERS
+            else if (rootKey.Equals("HKCC", StringComparison.OrdinalIgnoreCase) ||
+                rootKey.Equals("HKEY_CURRENT_CONFIG", StringComparison.OrdinalIgnoreCase))
+                regHive = RegistryHive.CurrentConfig; // HKEY_CURRENT_CONFIG
+            else
+                regHive = null;
+            return regHive;
+        }
+
+        [SupportedOSPlatform("windows")]
         public static RegistryKey? ParseStringToRegKey(string rootKey)
         {
             RegistryKey? regRoot;
@@ -125,6 +149,25 @@ namespace PEBakery.Helper
             else
                 regRoot = null;
             return regRoot;
+        }
+
+        [SupportedOSPlatform("windows")]
+        public static string? RegHiveToString(RegistryHive regHive)
+        {
+            string? rootKey;
+            if (regHive == RegistryHive.ClassesRoot)
+                rootKey = "HKCR";
+            else if (regHive == RegistryHive.CurrentUser)
+                rootKey = "HKCU";
+            else if (regHive == RegistryHive.LocalMachine)
+                rootKey = "HKLM";
+            else if (regHive == RegistryHive.Users)
+                rootKey = "HKU";
+            else if (regHive == RegistryHive.CurrentConfig)
+                rootKey = "HKCC";
+            else
+                rootKey = null;
+            return rootKey;
         }
 
         [SupportedOSPlatform("windows")]
@@ -249,10 +292,9 @@ namespace PEBakery.Helper
                 if (subKey == null)
                     throw new ArgumentException($"Unable to open subkey [{subKeyPath}]");
 
-                if (valueType == RegistryValueKind.Unknown ||
-                    !Enum.IsDefined(typeof(RegistryValueKind), valueType))
+                if (valueType == RegistryValueKind.Unknown || !Enum.IsDefined(valueType))
                 {
-                    // We don't know how to interprete byte array into C# objects.
+                    // We don't know how to interpret byte array into C# objects.
                     // Let's return raw byte array we received from RegQueryValueEx.
 
                     // Get required buffer size


### PR DESCRIPTION
## Summary

- Always use [RegistryView.Registry64](https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32.registryview?view=net-7.0) when handling registry.
    - Due to the introduction of self-contained build and ARM64 Windows machines, ensure PEBakery runs correctly on the WOW64 environment.
- Allow using variables in HKEY root argument.
- Support REG_* value type notations in `RegWrite` and `RegWriteEx`.