### PR TITLE
Bump target framework to .NET 8.0 from 6.0

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -10,12 +10,13 @@
     <ProjectReference Include="..\PEBakery.Helper\PEBakery.Helper.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="Joveler.Compression.LZ4" Version="4.1.0" />
-    <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
-    <PackageReference Include="Joveler.Compression.ZLib" Version="5.0.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="Joveler.Compression.LZ4" Version="5.0.0" />
+    <PackageReference Include="Joveler.Compression.XZ" Version="5.0.0" />
+    <PackageReference Include="Joveler.Compression.ZLib" Version="6.0.0" />
     <PackageReference Include="Joveler.FileMagician" Version="2.3.1" />
     <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="UTF.Unknown" Version="2.5.1" />
   </ItemGroup>
 </Project>

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Exe</OutputType>
     <Configurations>Debug;Release;Publish</Configurations>
     <Nullable>enable</Nullable>

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -107,7 +107,7 @@ namespace Benchmark
             CheckLibPath(lz4LibPath);
 
             Magic.GlobalInit(magicLibPath);
-            ZLibInit.GlobalInit(gzipLibPath);
+            ZLibInit.GlobalInit(gzipLibPath, new ZLibInitOptions());
             XZInit.GlobalInit(xzLibPath);
             LZ4Init.GlobalInit(lz4LibPath);
         }

--- a/Ookii.Dialogs.Wpf/CredentialException.cs
+++ b/Ookii.Dialogs.Wpf/CredentialException.cs
@@ -9,7 +9,6 @@ namespace Ookii.Dialogs.Wpf
     /// The exception that is thrown when an error occurs getting credentials.
     /// </summary>
     /// <threadsafety instance="false" static="true" />
-    [Serializable()]
     public class CredentialException : System.ComponentModel.Win32Exception
     {
         /// <summary>
@@ -55,16 +54,6 @@ namespace Ookii.Dialogs.Wpf
         /// <param name="innerException">A reference to the inner exception that is the cause of the current exception.</param>
         public CredentialException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CredentialException" /> class with serialized data.
-        /// </summary>
-        /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-        protected CredentialException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/Ookii.Dialogs.Wpf/Ookii.Dialogs.Wpf.csproj
+++ b/Ookii.Dialogs.Wpf/Ookii.Dialogs.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWpf>true</UseWpf>

--- a/PEBakery.Core.Tests/PEBakery.Core.Tests.csproj
+++ b/PEBakery.Core.Tests/PEBakery.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
     <UseWindowsForms>true</UseWindowsForms>

--- a/PEBakery.Core.Tests/PEBakery.Core.Tests.csproj
+++ b/PEBakery.Core.Tests/PEBakery.Core.Tests.csproj
@@ -17,13 +17,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ManagedWimLib" Version="2.5.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <PropertyGroup>
     <PostBuildEvent>REM XCOPY /S /I /Y "$(SolutionDir)Precompiled\Native\*" "$(TargetDir)"</PostBuildEvent>

--- a/PEBakery.Core/EncodedFile.cs
+++ b/PEBakery.Core/EncodedFile.cs
@@ -1455,7 +1455,7 @@ namespace PEBakery.Core
                                     Level = LzmaCompLevel.Default,
                                     LeaveOpen = true,
                                 };
-                                XZThreadedCompressOptions xzThreadOpts = new XZThreadedCompressOptions()
+                                XZParallelCompressOptions xzThreadOpts = new XZParallelCompressOptions()
                                 {
                                     Threads = threads,
                                 };
@@ -1816,7 +1816,7 @@ namespace PEBakery.Core
                                 {
                                     LeaveOpen = true,
                                 };
-                                XZThreadedDecompressOptions xzThreadOpts = new XZThreadedDecompressOptions()
+                                XZParallelDecompressOptions xzThreadOpts = new XZParallelDecompressOptions()
                                 {
                                     Threads = Environment.ProcessorCount,
                                     MemlimitThreading = availFreeMem,

--- a/PEBakery.Core/Global.cs
+++ b/PEBakery.Core/Global.cs
@@ -307,15 +307,15 @@ namespace PEBakery.Core
 
             try
             {
-                Joveler.FileMagician.Magic.GlobalInit(magicPath);
-                Joveler.Compression.ZLib.ZLibInit.GlobalInit(zlibPath, new Joveler.Compression.ZLib.ZLibInitOptions()
+                Joveler.FileMagician.Magic.GlobalInit(magicPath!);
+                Joveler.Compression.ZLib.ZLibInit.GlobalInit(zlibPath!, new Joveler.Compression.ZLib.ZLibInitOptions()
                 {
                     IsWindowsStdcall = false,
                     IsZLibNgModernAbi = false,
                 });
-                Joveler.Compression.XZ.XZInit.GlobalInit(xzPath);
-                ManagedWimLib.Wim.GlobalInit(wimlibPath);
-                SevenZip.SevenZipBase.SetLibraryPath(sevenZipPath);
+                Joveler.Compression.XZ.XZInit.GlobalInit(xzPath!);
+                ManagedWimLib.Wim.GlobalInit(wimlibPath!);
+                SevenZip.SevenZipBase.SetLibraryPath(sevenZipPath!);
             }
             catch (Exception e)
             {

--- a/PEBakery.Core/PEBakery.Core.csproj
+++ b/PEBakery.Core/PEBakery.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows7.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/PEBakery.Core/PEBakery.Core.csproj
+++ b/PEBakery.Core/PEBakery.Core.csproj
@@ -57,20 +57,21 @@
   <!-- NuGet Packages -->
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
-    <PackageReference Include="Joveler.Compression.ZLib" Version="5.0.0" />
+    <PackageReference Include="Joveler.Compression.XZ" Version="5.0.0" />
+    <PackageReference Include="Joveler.Compression.ZLib" Version="6.0.0" />
     <PackageReference Include="Joveler.FileMagician" Version="2.3.1" />
-    <PackageReference Include="MahApps.Metro.IconPacks.Material" Version="5.0.0" />
+    <PackageReference Include="MahApps.Metro.IconPacks.Material" Version="5.1.0" />
     <PackageReference Include="ManagedWimLib" Version="2.5.3" />
-    <PackageReference Include="MessagePack" Version="2.5.171" />
+    <PackageReference Include="MessagePack" Version="3.1.2" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="Microsoft.Wim" Version="1.2.11" />
     <PackageReference Include="NaturalSort.Extension" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUglify" Version="1.21.9" />
-    <PackageReference Include="Scriban" Version="5.10.0" />
+    <PackageReference Include="NUglify" Version="1.21.11" />
+    <PackageReference Include="Scriban" Version="5.12.1" />
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.6.2.24" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Timestamp" Version="1.0.2" />
     <PackageReference Include="UACHelper" Version="1.3.0.5" />
   </ItemGroup>

--- a/PEBakery.Core/Script.cs
+++ b/PEBakery.Core/Script.cs
@@ -47,8 +47,8 @@ namespace PEBakery.Core
     #endregion
 
     #region Script
-    [MessagePackObject]
-    public class Script : IEquatable<Script>
+    [MessagePackObject(AllowPrivate = true)]
+    public partial class Script : IEquatable<Script>
     {
         #region Const
         public static class Const

--- a/PEBakery.Core/ScriptSection.cs
+++ b/PEBakery.Core/ScriptSection.cs
@@ -98,8 +98,8 @@ namespace PEBakery.Core
     #endregion
 
     #region ScriptSection
-    [MessagePackObject]
-    public class ScriptSection : IEquatable<ScriptSection>
+    [MessagePackObject(AllowPrivate = true)]
+    public partial class ScriptSection : IEquatable<ScriptSection>
     {
         #region (Const) Known Section Names
         public static class Names

--- a/PEBakery.Helper.Tests/PEBakery.Helper.Tests.csproj
+++ b/PEBakery.Helper.Tests/PEBakery.Helper.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/PEBakery.Helper.Tests/PEBakery.Helper.Tests.csproj
+++ b/PEBakery.Helper.Tests/PEBakery.Helper.Tests.csproj
@@ -14,12 +14,13 @@
     <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/PEBakery.Helper/PEBakery.Helper.csproj
+++ b/PEBakery.Helper/PEBakery.Helper.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>

--- a/PEBakery.Helper/PEBakery.Helper.csproj
+++ b/PEBakery.Helper/PEBakery.Helper.csproj
@@ -10,11 +10,12 @@
     <Version>1.1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.5.171" />
-    <PackageReference Include="SharpVectors.Reloaded" Version="1.8.4">
+    <PackageReference Include="MessagePack" Version="3.1.2" />
+    <PackageReference Include="SharpVectors.Reloaded" Version="1.8.4.2">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="UACHelper" Version="1.3.0.5" />
   </ItemGroup>
 </Project>

--- a/PEBakery.Ini.Tests/PEBakery.Ini.Tests.csproj
+++ b/PEBakery.Ini.Tests/PEBakery.Ini.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Configurations>Debug;Release</Configurations>

--- a/PEBakery.Ini.Tests/PEBakery.Ini.Tests.csproj
+++ b/PEBakery.Ini.Tests/PEBakery.Ini.Tests.csproj
@@ -14,12 +14,13 @@
     <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/PEBakery.Ini/PEBakery.Ini.csproj
+++ b/PEBakery.Ini/PEBakery.Ini.csproj
@@ -7,6 +7,9 @@
       <Version>1.1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\PEBakery.Helper\PEBakery.Helper.csproj" />
   </ItemGroup>
 </Project>

--- a/PEBakery.Ini/PEBakery.Ini.csproj
+++ b/PEBakery.Ini/PEBakery.Ini.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-      <TargetFramework>net6.0-windows</TargetFramework>
+      <TargetFramework>net8.0-windows</TargetFramework>
       <Configurations>Debug;Release</Configurations>
       <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
       <Nullable>enable</Nullable>

--- a/PEBakery.Tree/PEBakery.Tree.csproj
+++ b/PEBakery.Tree/PEBakery.Tree.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Nullable>enable</Nullable>
     <Version>1.1.1.0</Version>

--- a/PEBakery/PEBakery.csproj
+++ b/PEBakery/PEBakery.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <!-- PackageReference Include="MahApps.Metro.IconPacks.Material" Version="4.11.0" /-->
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Timestamp" Version="1.0.2" />
   </ItemGroup>
 </Project>

--- a/PEBakery/PEBakery.csproj
+++ b/PEBakery/PEBakery.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows7.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,10 +15,10 @@ variables:
 
 steps:
 - task: UseDotNet@2
-  displayName: '[1-1] Install .NET SDK 6.0'
+  displayName: '[1-1] Install .NET SDK 8.0'
   inputs:
     packageType: 'sdk'
-    version: '6.0.x'
+    version: '8.0.x'
 - task: DotNetCoreCLI@2
   displayName: '[1-2] Install ReportGenerator Tool'
   inputs:


### PR DESCRIPTION
## Summary

.NET 6.0 is EOL now, so target .NET 8.0 (`net80-windows`).

- Windows 7/8.1 is no longer supported, as .NET 8.0 deprecated support for old Windows.
- Updated NuGet packages.
