### PR TITLE
Add percent-style section parameters as default notation

### DIFF
--- a/PEBakery.Core.Tests/Command/CommandControlTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandControlTests.cs
@@ -145,13 +145,13 @@ namespace PEBakery.Core.Tests.Command
             const string rawCode = "Set,#r,PEBakery";
 
             // Turn off compat option
-            s.CompatDisableExtendedSectionParams = false;
+            s.CompatDisableLegacyExtendedSectionParams = false;
             s.ReturnValue = string.Empty;
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
             Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
 
             // Turn on compat option
-            s.CompatDisableExtendedSectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = true;
             s.ReturnValue = string.Empty;
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
             Assert.IsTrue(s.ReturnValue.Length == 0);
@@ -162,13 +162,13 @@ namespace PEBakery.Core.Tests.Command
             const string rawCode = "Set,#r,NIL";
 
             // Turn off compat option
-            s.CompatDisableExtendedSectionParams = false;
+            s.CompatDisableLegacyExtendedSectionParams = false;
             s.ReturnValue = "PEBakery";
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
             Assert.IsTrue(s.ReturnValue.Length == 0);
 
             // Turn on compat option
-            s.CompatDisableExtendedSectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = true;
             s.ReturnValue = "PEBakery";
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
             Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));

--- a/PEBakery.Core.Tests/Command/CommandControlTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandControlTests.cs
@@ -52,10 +52,14 @@ namespace PEBakery.Core.Tests.Command
             SetGlobal(s);
             DelGlobal(s);
             SetDelPermanent(s);
-            SetReturnValue(s);
-            DelReturnValue(s);
-            SetLoopCounter(s);
-            DelLoopCounter(s);
+            SetReturnValuePercent(s);
+            SetReturnValueLegacy(s);
+            DelReturnValuePercent(s);
+            DelReturnValueLegacy(s);
+            SetLoopCounterPercent(s);
+            SetLoopCounterLegacy(s);
+            DelLoopCounterPercent(s);
+            DelLoopCounterLegacy(s);
         }
 
         public static void SetLocal(EngineState s)
@@ -140,46 +144,129 @@ namespace PEBakery.Core.Tests.Command
             }
         }
 
-        public static void SetReturnValue(EngineState s)
+        public static void SetReturnValuePercent(EngineState s)
+        {
+            const string rawCode = "Set,%^RET%,PEBakery";
+
+            // Turn off compat option
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatDisableLegacyExtendedSectionParams = false;
+            s.ReturnValue = string.Empty;
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatDisableLegacyExtendedSectionParams = true;
+            s.ReturnValue = string.Empty;
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = false;
+            s.ReturnValue = string.Empty;
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = true;
+            s.ReturnValue = string.Empty;
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
+        }
+
+        public static void SetReturnValueLegacy(EngineState s)
         {
             const string rawCode = "Set,#r,PEBakery";
 
-            // Turn off compat option
+            s.CompatEnableAllLegacySectionParams = false;
             s.CompatDisableLegacyExtendedSectionParams = false;
             s.ReturnValue = string.Empty;
-            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
-            Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            Assert.AreEqual(0, s.ReturnValue.Length);
 
-            // Turn on compat option
+            s.CompatEnableAllLegacySectionParams = false;
             s.CompatDisableLegacyExtendedSectionParams = true;
             s.ReturnValue = string.Empty;
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
-            Assert.IsTrue(s.ReturnValue.Length == 0);
+            Assert.AreEqual(0, s.ReturnValue.Length);
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = false;
+            s.ReturnValue = string.Empty;
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = true;
+            s.ReturnValue = string.Empty;
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            Assert.AreEqual(0, s.ReturnValue.Length);
         }
 
-        public static void DelReturnValue(EngineState s)
+        public static void DelReturnValuePercent(EngineState s)
         {
-            const string rawCode = "Set,#r,NIL";
+            const string rawCode = "Set,%^RET%,NIL";
 
-            // Turn off compat option
+            s.CompatEnableAllLegacySectionParams = false;
             s.CompatDisableLegacyExtendedSectionParams = false;
             s.ReturnValue = "PEBakery";
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
-            Assert.IsTrue(s.ReturnValue.Length == 0);
+            Assert.AreEqual(0, s.ReturnValue.Length);
 
-            // Turn on compat option
+            s.CompatEnableAllLegacySectionParams = false;
             s.CompatDisableLegacyExtendedSectionParams = true;
             s.ReturnValue = "PEBakery";
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.AreEqual(0, s.ReturnValue.Length);
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = false;
+            s.ReturnValue = "PEBakery";
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.AreEqual(0, s.ReturnValue.Length);
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = true;
+            s.ReturnValue = "PEBakery";
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.AreEqual(0, s.ReturnValue.Length);
+        }
+
+        public static void DelReturnValueLegacy(EngineState s)
+        {
+            const string rawCode = "Set,#r,NIL";
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatDisableLegacyExtendedSectionParams = false;
+            s.ReturnValue = "PEBakery";
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatDisableLegacyExtendedSectionParams = true;
+            s.ReturnValue = "PEBakery";
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = false;
+            s.ReturnValue = "PEBakery";
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Success);
+            Assert.AreEqual(0, s.ReturnValue.Length);
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatDisableLegacyExtendedSectionParams = true;
+            s.ReturnValue = "PEBakery";
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
             Assert.IsTrue(s.ReturnValue.Equals("PEBakery", StringComparison.Ordinal));
         }
 
-        public static void SetLoopCounter(EngineState s)
+        public static void SetLoopCounterPercent(EngineState s)
         {
             s.LoopCmdStateStack.Clear();
 
             // Simulate Loop command
-            const string rawLoopCode = "Set,#c,110";
+            const string rawLoopCode = "Set,%^LOOP_IDX%,110";
 
             s.CompatOverridableLoopCounter = true;
             s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
@@ -194,7 +281,7 @@ namespace PEBakery.Core.Tests.Command
             Assert.AreEqual(100, loop.CounterIndex);
 
             // Simulate LoopLetter command
-            const string rawLoopLetterCode = "Set,#c,Z";
+            const string rawLoopLetterCode = "Set,%^LOOP_IDX%,Z";
 
             s.CompatOverridableLoopCounter = true;
             s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
@@ -226,10 +313,95 @@ namespace PEBakery.Core.Tests.Command
             Assert.AreEqual(0, s.LoopCmdStateStack.Count);
         }
 
-        public static void DelLoopCounter(EngineState s)
+        public static void SetLoopCounterLegacy(EngineState s)
+        {
+            s.LoopCmdStateStack.Clear();
+
+            // Simulate Loop command
+            const string rawLoopCode = "Set,#c,110";
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatOverridableLoopCounter = true;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawLoopCode, CodeType.Set, ErrorCheck.Success);
+            EngineLoopCmdState loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(110, loop.CounterIndex);
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatOverridableLoopCounter = false;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawLoopCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatOverridableLoopCounter = true;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawLoopCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatOverridableLoopCounter = false;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawLoopCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+
+            // Simulate LoopLetter command
+            const string rawLoopLetterCode = "Set,#c,Z";
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatOverridableLoopCounter = true;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawLoopLetterCode, CodeType.Set, ErrorCheck.Success);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual('Z', loop.CounterLetter);
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatOverridableLoopCounter = false;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawLoopLetterCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual('C', loop.CounterLetter);
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatOverridableLoopCounter = true;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawLoopLetterCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual('C', loop.CounterLetter);
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatOverridableLoopCounter = false;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawLoopLetterCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual('C', loop.CounterLetter);
+
+            // Error 
+            s.LoopCmdStateStack.Clear();
+            EngineTests.Eval(s, rawLoopCode, CodeType.Set, ErrorCheck.Warning);
+            Assert.AreEqual(0, s.LoopCmdStateStack.Count);
+
+            s.LoopCmdStateStack.Clear();
+            EngineTests.Eval(s, rawLoopCode, CodeType.Set, ErrorCheck.Warning);
+            Assert.AreEqual(0, s.LoopCmdStateStack.Count);
+
+            s.LoopCmdStateStack.Clear();
+            EngineTests.Eval(s, rawLoopLetterCode, CodeType.Set, ErrorCheck.Warning);
+            Assert.AreEqual(0, s.LoopCmdStateStack.Count);
+
+            s.LoopCmdStateStack.Clear();
+            EngineTests.Eval(s, rawLoopLetterCode, CodeType.Set, ErrorCheck.Warning);
+            Assert.AreEqual(0, s.LoopCmdStateStack.Count);
+        }
+
+        public static void DelLoopCounterPercent(EngineState s)
         {
             const string rawCode = "Set,#c,NIL";
 
+            s.CompatEnableAllLegacySectionParams = true;
             s.CompatOverridableLoopCounter = true;
             s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
@@ -243,6 +415,103 @@ namespace PEBakery.Core.Tests.Command
             Assert.AreEqual(0, loop.CounterIndex);
             Assert.AreEqual('C', loop.CounterLetter);
 
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatOverridableLoopCounter = false;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+            Assert.AreEqual('\0', loop.CounterLetter);
+
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(0, loop.CounterIndex);
+            Assert.AreEqual('C', loop.CounterLetter);
+
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatOverridableLoopCounter = true;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+            Assert.AreEqual('\0', loop.CounterLetter);
+
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(0, loop.CounterIndex);
+            Assert.AreEqual('C', loop.CounterLetter);
+
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatOverridableLoopCounter = false;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+            Assert.AreEqual('\0', loop.CounterLetter);
+
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(0, loop.CounterIndex);
+            Assert.AreEqual('C', loop.CounterLetter);
+        }
+
+        public static void DelLoopCounterLegacy(EngineState s)
+        {
+            const string rawCode = "Set,#c,NIL";
+
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatOverridableLoopCounter = true;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            EngineLoopCmdState loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+            Assert.AreEqual('\0', loop.CounterLetter);
+
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(0, loop.CounterIndex);
+            Assert.AreEqual('C', loop.CounterLetter);
+
+
+            s.CompatEnableAllLegacySectionParams = true;
+            s.CompatOverridableLoopCounter = false;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+            Assert.AreEqual('\0', loop.CounterLetter);
+
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(0, loop.CounterIndex);
+            Assert.AreEqual('C', loop.CounterLetter);
+
+
+            s.CompatEnableAllLegacySectionParams = false;
+            s.CompatOverridableLoopCounter = true;
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(100, loop.CounterIndex);
+            Assert.AreEqual('\0', loop.CounterLetter);
+
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('C'));
+            EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);
+            loop = s.LoopCmdStateStack.Pop();
+            Assert.AreEqual(0, loop.CounterIndex);
+            Assert.AreEqual('C', loop.CounterLetter);
+
+
+            s.CompatEnableAllLegacySectionParams = false;
             s.CompatOverridableLoopCounter = false;
             s.LoopCmdStateStack.Push(new EngineLoopCmdState(100));
             EngineTests.Eval(s, rawCode, CodeType.Set, ErrorCheck.Warning);

--- a/PEBakery.Core.Tests/Command/CommandNetworkTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandNetworkTests.cs
@@ -232,7 +232,7 @@ namespace PEBakery.Core.Tests.Command
 
                 Assert.IsTrue(File.Exists(destFile));
                 Assert.IsTrue(TestSetup.FileEqual(srcFile, destFile));
-                Assert.IsTrue(s.ReturnValue.Length == 0);
+                Assert.IsTrue(s.ReturnValue.Equals("200", StringComparison.Ordinal)); // Always set ReturnValue, regardless of DisableLegacyExtendedSectionParams.
             }
             finally
             {

--- a/PEBakery.Core.Tests/Command/CommandNetworkTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandNetworkTests.cs
@@ -228,7 +228,7 @@ namespace PEBakery.Core.Tests.Command
 
                 string srcFile = Path.Combine(TestSetup.WebRoot, "index.html");
                 string rawCode = $"WebGet,\"{TestSetup.UrlRoot}/index.html\",\"{destFile}\"";
-                EngineTests.Eval(s, rawCode, CodeType.WebGet, ErrorCheck.Success, new CompatOption { DisableExtendedSectionParams = true });
+                EngineTests.Eval(s, rawCode, CodeType.WebGet, ErrorCheck.Success, new CompatOption { DisableLegacyExtendedSectionParams = true });
 
                 Assert.IsTrue(File.Exists(destFile));
                 Assert.IsTrue(TestSetup.FileEqual(srcFile, destFile));

--- a/PEBakery.Core.Tests/Command/CommandRegistryTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandRegistryTests.cs
@@ -113,23 +113,23 @@ namespace PEBakery.Core.Tests.Command
                 // [*] Test HKEY roots in variable
                 s.ReturnValue = "HKCU";
                 // Unknown
-                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,#r,{subKeyStr},Extra,%Dest%", "00,01,02",
+                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,%^RET%,{subKeyStr},Extra,%Dest%", "00,01,02",
                     RegistryHive.CurrentUser, 0x200000, subKeyStr, "Extra", new byte[] { 00, 01, 02 });
-                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,#r,{subKeyStr},Extra,%Dest%", "03,04",
+                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,%^RET%,{subKeyStr},Extra,%Dest%", "03,04",
                     RegistryHive.CurrentUser, 0x100000, subKeyStr, "Extra", new byte[] { 03, 04 });
-                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,#r,{subKeyStr},Extra,%Dest%", "05,06,07",
+                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,%^RET%,{subKeyStr},Extra,%Dest%", "05,06,07",
                     RegistryHive.CurrentUser, 0xFFff0009, subKeyStr, "Extra", new byte[] { 05, 06, 07 });
-                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,#r,{subKeyStr},Extra,%Dest%", "08,09",
+                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,%^RET%,{subKeyStr},Extra,%Dest%", "08,09",
                     RegistryHive.CurrentUser, 0xffFF100d, subKeyStr, "Extra", new byte[] { 08, 09 });
-                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,#r,{subKeyStr},Extra,%Dest%", string.Empty,
+                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,%^RET%,{subKeyStr},Extra,%Dest%", string.Empty,
                     RegistryHive.CurrentUser, 0xFFff2012, subKeyStr, "Extra", Array.Empty<byte>());
                 // REG_DWORD
-                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,#r,{subKeyStr},UInt32,%Dest%", "1234",
+                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,%^RET%,{subKeyStr},UInt32,%Dest%", "1234",
                     RegistryHive.CurrentUser, (uint)RegistryValueKind.DWord, subKeyStr, "UInt32", 1234u);
-                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,#r,{subKeyStr},UInt32,%Dest%", "4294967295",
+                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,%^RET%,{subKeyStr},UInt32,%Dest%", "4294967295",
                     RegistryHive.CurrentUser, (uint)RegistryValueKind.DWord, subKeyStr, "UInt32", 4294967295u);
                 // REG_QWORD
-                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,#r,{subKeyStr},UInt64,%Dest%", "4294967296",
+                ReadWriteTemplate(s, CodeType.RegRead, $@"RegRead,%^RET%,{subKeyStr},UInt64,%Dest%", "4294967296",
                     RegistryHive.CurrentUser, (uint)RegistryValueKind.QWord, subKeyStr, "UInt64", 4294967296ul);
             }
             finally
@@ -221,18 +221,18 @@ namespace PEBakery.Core.Tests.Command
                     RegistryHive.CurrentUser, RegistryValueKind.QWord, subKeyStr, "QWORD", 4294967296ul);
 
                 // was RegWriteLegacy
-                WriteVarSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,#r,0x4,{subKeyStr},DWORD,1234", "HKCU",
+                WriteVarSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,%^RET%,0x4,{subKeyStr},DWORD,1234", "HKCU",
                     RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
                     new CompatOption { LegacyRegWrite = true });
-                WriteVarSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,#r,0x4,{subKeyStr},DWORD,1234", "HKCU",
+                WriteVarSuccessTemplate(s, CodeType.RegWrite, $@"RegWrite,%^RET%,0x4,{subKeyStr},DWORD,1234", "HKCU",
                     RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u, 
                     new CompatOption());
 
                 // still is RegWriteLegacy
-                WriteVarSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,#r,{subKeyStr},DWORD,1234", "0x4",
+                WriteVarSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,%^RET%,{subKeyStr},DWORD,1234", "0x4",
                     RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
                     new CompatOption { LegacyRegWrite = true });
-                WriteVarSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,#r,{subKeyStr},DWORD,1234", "0x4",
+                WriteVarSuccessTemplate(s, CodeType.RegWriteLegacy, $@"RegWrite,HKCU,%^RET%,{subKeyStr},DWORD,1234", "0x4",
                     RegistryHive.CurrentUser, RegistryValueKind.DWord, subKeyStr, "DWORD", 1234u,
                     new CompatOption(), ErrorCheck.ParserError);
 
@@ -281,16 +281,16 @@ namespace PEBakery.Core.Tests.Command
                 s.ReturnValue = "HKCU";
                 try
                 {
-                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,#r,0x200000,{subKeyStr},Extra,00,01,02",
+                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,%^RET%,0x200000,{subKeyStr},Extra,00,01,02",
                     RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 00, 01, 02 });
-                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,#r,0x100000,{subKeyStr},Extra,""03,04""",
+                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,%^RET%,0x100000,{subKeyStr},Extra,""03,04""",
                         RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 03, 04 },
                         null, ErrorCheck.Overwrite);
-                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,#r,0xFFff0009,{subKeyStr},Extra,05,06,07,NOWARN",
+                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,%^RET%,0xFFff0009,{subKeyStr},Extra,05,06,07,NOWARN",
                         RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 05, 06, 07 });
-                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,#r,0xffFF100d,{subKeyStr},Extra,""08,09"",NOWARN",
+                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,%^RET%,0xffFF100d,{subKeyStr},Extra,""08,09"",NOWARN",
                         RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", new byte[] { 08, 09 });
-                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,#r,0xFFff2012,{subKeyStr},Extra,,NOWARN",
+                    WriteSuccessTemplate(s, CodeType.RegWriteEx, $@"RegWriteEx,%^RET%,0xFFff2012,{subKeyStr},Extra,,NOWARN",
                         RegistryHive.CurrentUser, RegistryValueKind.Unknown, subKeyStr, "Extra", Array.Empty<byte>());
                 }
                 finally
@@ -372,8 +372,8 @@ namespace PEBakery.Core.Tests.Command
                 s.ReturnValue = "HKCU";
                 try
                 {
-                    Template($@"RegDelete,#r,{RegDeletePath},ValueName", RegistryHive.CurrentUser, RegDeletePath, "ValueName");
-                    Template($@"RegDelete,#r,{RegDeletePath}", RegistryHive.CurrentUser, RegDeletePath, null);
+                    Template($@"RegDelete,%^RET%,{RegDeletePath},ValueName", RegistryHive.CurrentUser, RegDeletePath, "ValueName");
+                    Template($@"RegDelete,%^RET%,{RegDeletePath}", RegistryHive.CurrentUser, RegDeletePath, null);
                 }
                 finally
                 {
@@ -472,32 +472,32 @@ namespace PEBakery.Core.Tests.Command
             try
             {
                 // Append
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Append,C", new string[] { "A", "B", "C" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Append,B", new string[] { "A", "B" }, ErrorCheck.Warning);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Append,C", ["A", "B", "C"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Append,B", ["A", "B"], ErrorCheck.Warning);
                 // Prepend
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Prepend,C", new string[] { "C", "A", "B" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Prepend,A", new string[] { "A", "B" }, ErrorCheck.Warning);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Prepend,C", ["C", "A", "B"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Prepend,A", ["A", "B"], ErrorCheck.Warning);
                 // Before
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Before,A,C", new string[] { "C", "A", "B" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Before,B,C", new string[] { "A", "C", "B" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Before,D,C", new string[] { "A", "B" }, ErrorCheck.RuntimeError);
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Before,A,B", new string[] { "A", "B" }, ErrorCheck.Warning);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Before,A,C", ["C", "A", "B"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Before,B,C", ["A", "C", "B"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Before,D,C", ["A", "B"], ErrorCheck.RuntimeError);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Before,A,B", ["A", "B"], ErrorCheck.Warning);
                 // Behind
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Behind,A,C", new string[] { "A", "C", "B" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Behind,B,C", new string[] { "A", "B", "C" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Behind,D,C", new string[] { "A", "B" }, ErrorCheck.RuntimeError);
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Behind,A,B", new string[] { "A", "B" }, ErrorCheck.Warning);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Behind,A,C", ["A", "C", "B"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Behind,B,C", ["A", "B", "C"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Behind,D,C", ["A", "B"], ErrorCheck.RuntimeError);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Behind,A,B", ["A", "B"], ErrorCheck.Warning);
                 // Place
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,1,C", new string[] { "C", "A", "B" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,2,C", new string[] { "A", "C", "B" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,3,C", new string[] { "A", "B", "C" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,0,C", new string[] { "C", "A", "B" }, ErrorCheck.RuntimeError);
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,4,C", new string[] { "C", "A", "B" }, ErrorCheck.RuntimeError);
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,1,B", new string[] { "A", "B" }, ErrorCheck.Warning);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,1,C", ["C", "A", "B"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,2,C", ["A", "C", "B"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,3,C", ["A", "B", "C"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,0,C", ["C", "A", "B"], ErrorCheck.RuntimeError);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,4,C", ["C", "A", "B"], ErrorCheck.RuntimeError);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Place,1,B", ["A", "B"], ErrorCheck.Warning);
                 // Delete
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Delete,A", new string[] { "B" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Delete,B", new string[] { "A" });
-                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Delete,C", new string[] { "A", "B" }, ErrorCheck.RuntimeError);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Delete,A", ["B"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Delete,B", ["A"]);
+                NormalTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Delete,C", ["A", "B"], ErrorCheck.RuntimeError);
                 // Index
                 IndexTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Index,A,%Dest%", 1, "A");
                 IndexTemplate($@"RegMulti,HKCU,{subKeyStr},Key,Index,B,%Dest%", 2, "B");
@@ -507,13 +507,13 @@ namespace PEBakery.Core.Tests.Command
                 s.ReturnValue = "HKCU";
                 try
                 {
-                    NormalTemplate($@"RegMulti,#r,{subKeyStr},Key,Append,C", new string[] { "A", "B", "C" });
-                    NormalTemplate($@"RegMulti,#r,{subKeyStr},Key,Prepend,A", new string[] { "A", "B" }, ErrorCheck.Warning);
-                    NormalTemplate($@"RegMulti,#r,{subKeyStr},Key,Before,D,C", new string[] { "A", "B" }, ErrorCheck.RuntimeError);
-                    NormalTemplate($@"RegMulti,#r,{subKeyStr},Key,Behind,B,C", new string[] { "A", "B", "C" });
-                    NormalTemplate($@"RegMulti,#r,{subKeyStr},Key,Place,1,B", new string[] { "A", "B" }, ErrorCheck.Warning);
-                    NormalTemplate($@"RegMulti,#r,{subKeyStr},Key,Delete,A", new string[] { "B" });
-                    IndexTemplate($@"RegMulti,#r,{subKeyStr},Key,Index,B,%Dest%", 2, "B");
+                    NormalTemplate($@"RegMulti,%^RET%,{subKeyStr},Key,Append,C", ["A", "B", "C"]);
+                    NormalTemplate($@"RegMulti,%^RET%,{subKeyStr},Key,Prepend,A", ["A", "B"], ErrorCheck.Warning);
+                    NormalTemplate($@"RegMulti,%^RET%,{subKeyStr},Key,Before,D,C", ["A", "B"], ErrorCheck.RuntimeError);
+                    NormalTemplate($@"RegMulti,%^RET%,{subKeyStr},Key,Behind,B,C", ["A", "B", "C"]);
+                    NormalTemplate($@"RegMulti,%^RET%,{subKeyStr},Key,Place,1,B", ["A", "B"], ErrorCheck.Warning);
+                    NormalTemplate($@"RegMulti,%^RET%,{subKeyStr},Key,Delete,A", ["B"]);
+                    IndexTemplate($@"RegMulti,%^RET%,{subKeyStr},Key,Index,B,%Dest%", 2, "B");
                 }
                 finally
                 {
@@ -695,24 +695,24 @@ namespace PEBakery.Core.Tests.Command
             SingleTemplate($@"RegCopy,HKCU,{singleSrcSet},HKCU,{destSet}", RegistryHive.CurrentUser,
                 singleSrcSet, destSet);
             WildcardTemplate($@"RegCopy,HKCU,{multiSrcSet1},HKCU,{destSet},WILDCARD", RegistryHive.CurrentUser,
-                RegCopyPath, new string[] { "Set10", "Set20", "Set31" },
-                destSet, new string[] { "Set10", "Set20", "Set31" });
+                RegCopyPath, ["Set10", "Set20", "Set31"],
+                destSet, ["Set10", "Set20", "Set31"]);
             WildcardTemplate($@"RegCopy,HKCU,{multiSrcSet2},HKCU,{destSet},WILDCARD", RegistryHive.CurrentUser,
-                RegCopyPath, new string[] { "Set10", "Set20", "Set31" },
-                destSet, new string[] { "Set10", "Set20" });
+                RegCopyPath, ["Set10", "Set20", "Set31"],
+                destSet, ["Set10", "Set20"]);
 
             // Success - HKEY root in a variable
             s.ReturnValue = "HKCU";
             try
             {
-                SingleTemplate($@"RegCopy,#r,{singleSrcSet},#r,{destSet}", RegistryHive.CurrentUser,
+                SingleTemplate($@"RegCopy,%^RET%,{singleSrcSet},%^RET%,{destSet}", RegistryHive.CurrentUser,
                 singleSrcSet, destSet);
-                WildcardTemplate($@"RegCopy,#r,{multiSrcSet1},#r,{destSet},WILDCARD", RegistryHive.CurrentUser,
-                    RegCopyPath, new string[] { "Set10", "Set20", "Set31" },
-                    destSet, new string[] { "Set10", "Set20", "Set31" });
-                WildcardTemplate($@"RegCopy,#r,{multiSrcSet2},#r,{destSet},WILDCARD", RegistryHive.CurrentUser,
-                    RegCopyPath, new string[] { "Set10", "Set20", "Set31" },
-                    destSet, new string[] { "Set10", "Set20" });
+                WildcardTemplate($@"RegCopy,%^RET%,{multiSrcSet1},%^RET%,{destSet},WILDCARD", RegistryHive.CurrentUser,
+                    RegCopyPath, ["Set10", "Set20", "Set31"],
+                    destSet, ["Set10", "Set20", "Set31"]);
+                WildcardTemplate($@"RegCopy,%^RET%,{multiSrcSet2},%^RET%,{destSet},WILDCARD", RegistryHive.CurrentUser,
+                    RegCopyPath, ["Set10", "Set20", "Set31"],
+                    destSet, ["Set10", "Set20"]);
             }
             finally
             {
@@ -723,12 +723,12 @@ namespace PEBakery.Core.Tests.Command
             SingleTemplate($@"RegCopy,HKCU,{singleSrcSet},HKCU,{destSet},WILDCARD", RegistryHive.CurrentUser,
                 singleSrcSet, destSet, ErrorCheck.RuntimeError);
             WildcardTemplate($@"RegCopy,HKCU,{multiSrcSet1},HKCU,{destSet}", RegistryHive.CurrentUser,
-                RegCopyPath, new string[] { "Set10", "Set20", "Set31" },
-                destSet, new string[] { "Set10", "Set20", "Set31" },
+                RegCopyPath, ["Set10", "Set20", "Set31"],
+                destSet, ["Set10", "Set20", "Set31"],
                 ErrorCheck.RuntimeError);
             WildcardTemplate($@"RegCopy,HKCU,{multiSrcSet2},HKCU,{destSet}", RegistryHive.CurrentUser,
-                RegCopyPath, new string[] { "Set10", "Set20", "Set31" },
-                destSet, new string[] { "Set10", "Set20" },
+                RegCopyPath, ["Set10", "Set20", "Set31"],
+                destSet, ["Set10", "Set20"],
                 ErrorCheck.RuntimeError);
 
             #region CreateRegValues, CheckRegValues

--- a/PEBakery.Core.Tests/Command/CommandSystemTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandSystemTests.cs
@@ -246,7 +246,7 @@ namespace PEBakery.Core.Tests.Command
                         s.Variables[exitKey] = string.Empty;
 
                     if (enableCompat)
-                        EngineTests.Eval(s, rawCode, CodeType.ShellExecute, check, new CompatOption { DisableExtendedSectionParams = true });
+                        EngineTests.Eval(s, rawCode, CodeType.ShellExecute, check, new CompatOption { DisableLegacyExtendedSectionParams = true });
                     else
                         EngineTests.Eval(s, rawCode, CodeType.ShellExecute, check);
 

--- a/PEBakery.Core.Tests/Command/CommandSystemTests.cs
+++ b/PEBakery.Core.Tests/Command/CommandSystemTests.cs
@@ -53,25 +53,25 @@ namespace PEBakery.Core.Tests.Command
                 EngineTests.EvalScript(treePath, check);
             }
 
-            SingleTemplate(new List<string>
-            {
+            SingleTemplate(
+            [
                 @"System,ErrorOff",
                 @"Error1",
-            });
-            SingleTemplate(new List<string>
-            {
+            ]);
+            SingleTemplate(
+            [
                 @"System,ErrorOff,3",
                 @"Error1",
                 @"Error2",
                 @"Error3",
-            });
-            SingleTemplate(new List<string>
-            {
+            ]);
+            SingleTemplate(
+            [
                 @"System,ErrorOff,2",
                 @"Error1",
                 @"Error2",
                 @"Error3",
-            }, ErrorCheck.RuntimeError);
+            ], ErrorCheck.RuntimeError);
 
             string scPath = Path.Combine(EngineTests.Project.ProjectName, "System", "ErrorOff.script");
             ScriptTemplate(scPath);
@@ -124,7 +124,6 @@ namespace PEBakery.Core.Tests.Command
                         for (int i = 1; i < paths.Length - 1; i++)
                         {
                             string destTreeDir = Project.PathKeyGenerator(paths, i);
-                            Assert.IsNotNull(destTreeDir);
                             Assert.IsTrue(s.Project.ContainsScriptByTreePath(destTreeDir));
                         }
                         Assert.IsTrue(s.Project.ContainsScriptByTreePath(destTreePath));
@@ -132,25 +131,25 @@ namespace PEBakery.Core.Tests.Command
                 }
             }
 
-            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\Blank1.script,", new string[] { @"TestSuite\Blank1.script" });
-            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\Blank1.script,Load", new string[] { @"TestSuite\Load\Blank1.script" });
-            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\Blank?.script,Load", new string[]
-            {
+            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\Blank1.script,", [@"TestSuite\Blank1.script"]);
+            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\Blank1.script,Load", [@"TestSuite\Load\Blank1.script"]);
+            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\Blank?.script,Load",
+            [
                 @"TestSuite\Load\Blank1.script",
                 @"TestSuite\Load\Blank2.script"
-            });
-            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\*.script,Load\Tree", new string[]
-            {
+            ]);
+            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\*.script,Load\Tree",
+            [
                 @"TestSuite\Load\Tree\Blank1.script",
                 @"TestSuite\Load\Tree\Blank2.script",
                 @"TestSuite\Load\Tree\Sub\Sub1.script",
                 @"TestSuite\Load\Tree\Sub\Sub2.script",
-            });
-            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\*.script,Load,NOREC", new string[]
-            {
+            ]);
+            Template(@"System,LoadNewScript,%TestBench%\CommandSystem\*.script,Load,NOREC",
+            [
                 @"TestSuite\Load\Blank1.script",
                 @"TestSuite\Load\Blank2.script",
-            });
+            ]);
         }
         #endregion
 
@@ -194,25 +193,25 @@ namespace PEBakery.Core.Tests.Command
                 }
             }
 
-            SingleTemplate(new List<string>
-            {
+            SingleTemplate(
+            [
                 @"Set,%Dest%,0",
-                @"Set,#r,A",
+                @"Set,%^RET%,A",
                 @"System,SetLocal",
                 @"Set,%Dest%,1",
-                @"Set,#r,B",
+                @"Set,%^RET%,B",
                 @"System,EndLocal",
-            }, "0", "B");
-            SingleTemplate(new List<string>
-            {
+            ], "0", "B");
+            SingleTemplate(
+            [
                 @"System,SetLocal",
                 @"System,SetLocal",
                 @"System,EndLocal",
-            }, null, null, ErrorCheck.RuntimeError);
-            SingleTemplate(new List<string>
-            {
+            ], null, null, ErrorCheck.RuntimeError);
+            SingleTemplate(
+            [
                 @"System,EndLocal",
-            }, null, null, ErrorCheck.RuntimeError);
+            ], null, null, ErrorCheck.RuntimeError);
 
             string scPath = Path.Combine(EngineTests.Project.ProjectName, "System", "SetEndLocal.script");
             ScriptTemplate(scPath, "Process-Simple", "0", "B");

--- a/PEBakery.Core.Tests/EngineTests.cs
+++ b/PEBakery.Core.Tests/EngineTests.cs
@@ -420,9 +420,9 @@ namespace PEBakery.Core.Tests
                 case ErrorCheck.Success:
                     foreach (LogInfo log in logs)
                     {
-                        Assert.IsTrue(log.State != LogState.Error);
-                        Assert.IsTrue(log.State != LogState.CriticalError);
-                        Assert.IsTrue(log.State != LogState.Warning);
+                        Assert.AreNotEqual(LogState.Error, log.State);
+                        Assert.AreNotEqual(LogState.CriticalError, log.State);
+                        Assert.AreNotEqual(LogState.Warning, log.State);
                     }
                     break;
                 case ErrorCheck.Warning:
@@ -430,8 +430,8 @@ namespace PEBakery.Core.Tests
                         bool result = false;
                         foreach (LogInfo log in logs)
                         {
-                            Assert.IsTrue(log.State != LogState.Error);
-                            Assert.IsTrue(log.State != LogState.CriticalError);
+                            Assert.AreNotEqual(LogState.Error, log.State);
+                            Assert.AreNotEqual(LogState.CriticalError, log.State);
                             if (log.State == LogState.Warning)
                                 result = true;
                         }
@@ -443,8 +443,8 @@ namespace PEBakery.Core.Tests
                         bool result = false;
                         foreach (LogInfo log in logs)
                         {
-                            Assert.IsTrue(log.State != LogState.Error);
-                            Assert.IsTrue(log.State != LogState.CriticalError);
+                            Assert.AreNotEqual(LogState.Error, log.State);
+                            Assert.AreNotEqual(LogState.CriticalError, log.State);
                             if (log.State == LogState.Overwrite)
                                 result = true;
                         }
@@ -456,7 +456,7 @@ namespace PEBakery.Core.Tests
                         bool result = false;
                         foreach (LogInfo log in logs)
                         {
-                            Assert.IsTrue(log.State != LogState.CriticalError);
+                            Assert.AreNotEqual(LogState.CriticalError, log.State);
                             if (log.State == LogState.Error)
                                 result = true;
                         }

--- a/PEBakery.Core.Tests/Samples/Projects/TestSuite/Branch/Exec.script
+++ b/PEBakery.Core.Tests/Samples/Projects/TestSuite/Branch/Exec.script
@@ -11,4 +11,4 @@ Mandatory=False
 %ExecVar%=T
 
 [SetTrue]
-Set,#r,%ExecVar%
+Set,%^RET%,%ExecVar%

--- a/PEBakery.Core.Tests/Samples/Projects/TestSuite/Branch/General.script
+++ b/PEBakery.Core.Tests/Samples/Projects/TestSuite/Branch/General.script
@@ -8,7 +8,7 @@ Selected=True
 Mandatory=False
 
 [Variables]
-InlineMacro=Set,#r,#1
+InlineMacro=Set,%^RET%,%^SIPARAM_1%
 
 [Process-Run]
 Set,%Dest%,F
@@ -30,7 +30,7 @@ RunEx,%ScriptFile%,SetOutParam,In=T
 Set,%Dest%,F
 Set,%ExecVar%,F
 Exec,%ScriptDir%\Exec.script,SetTrue
-Set,%Dest%,#r
+Set,%Dest%,%^RET%
 
 [Process-Exec-MacroBak]
 // Test if Exec command successfully preserves local macro dictionary.
@@ -40,16 +40,16 @@ Set,%Dest%,F
 Set,%ExecVar%,F
 Exec,%ScriptDir%\Exec.script,SetTrue
 InlineMacro,T
-Set,%Dest%,#r
+Set,%Dest%,%^RET%
 
 [SetTrue]
 Set,%Dest%,T
 
 [SetParam]
-Set,%Dest%,#1
+Set,%Dest%,%^SIPARAM_1%
 
 [SetOutParam]
-Set,#o1,#1
+Set,%^SOPARAM_1%,%^SIPARAM_1%
 
 [Process-Loop01]
 Set,%Dest%,NIL
@@ -96,30 +96,30 @@ Set,%Dest%,NIL
 Loop,%ScriptFile%,LoopNestFirst,1,3
 
 [LoopTest]
-List,Append,%Dest%,#c
-List,Append,%Dest%,#1
+List,Append,%Dest%,%^LOOP_IDX%
+List,Append,%Dest%,%^SIPARAM_1%
 
 [LoopOutParam]
-List,Append,#o1,#c
-List,Append,#o1,#1
+List,Append,%^SOPARAM_1%,%^LOOP_IDX%
+List,Append,%^SOPARAM_1%,%^SIPARAM_1%
 
 [LoopBreak]
-List,Append,%Dest%,#c
-List,Append,%Dest%,#1
-If,#c,Equal,#2,Loop,BREAK
+List,Append,%Dest%,%^LOOP_IDX%
+List,Append,%Dest%,%^SIPARAM_1%
+If,%^LOOP_IDX%,Equal,%^SIPARAM_2%,Loop,BREAK
 
 [LoopNestFirst]
-List,Append,%Dest%,#c
+List,Append,%Dest%,%^LOOP_IDX%
 Loop,%ScriptFile%,LoopNestSecond,4,5
-List,Append,%Dest%,#c
+List,Append,%Dest%,%^LOOP_IDX%
 
 [LoopNestSecond]
-List,Append,%Dest%,#c
+List,Append,%Dest%,%^LOOP_IDX%
 
 [Process-IfElse01]
 Set,%Dest%,F
-Set,#r,False
-If,#r,Equal,True,Begin
+Set,%^RET%,False
+If,%^RET%,Equal,True,Begin
   Set,%Dest%,F
 End
 Else,Begin
@@ -128,8 +128,8 @@ End
 
 [Process-IfElse02]
 Set,%Dest%,F
-Set,#r,""
-If,#r,Equal,True,Begin
+Set,%^RET%,""
+If,%^RET%,Equal,True,Begin
   Set,%Dest%,F
 End
 Else,Begin
@@ -139,126 +139,126 @@ Set,%Dest%,T
 
 [Process-IfElseChain01]
 Set,%Dest%,F
-Set,#r,5
-If,#r,Equal,1,Set,%Dest%,F
-Else,If,#r,Equal,2,Set,%Dest%,F
-Else,If,#r,Equal,3,Set,%Dest%,F
+Set,%^RET%,5
+If,%^RET%,Equal,1,Set,%Dest%,F
+Else,If,%^RET%,Equal,2,Set,%Dest%,F
+Else,If,%^RET%,Equal,3,Set,%Dest%,F
 // Comment must not crash CodeParser by resetting the elseFlag.
-Else,If,#r,Equal,4,Set,%Dest%,F
-Else,If,#r,Equal,5,Set,%Dest%,T
+Else,If,%^RET%,Equal,4,Set,%Dest%,F
+Else,If,%^RET%,Equal,5,Set,%Dest%,T
 
 [Process-IfElseChain02]
 Set,%Dest%,F
-Set,#r,5
-If,#r,Equal,1,Begin
+Set,%^RET%,5
+If,%^RET%,Equal,1,Begin
   Set,%Dest%,F
 End
-Else,If,#r,Equal,2,Begin
+Else,If,%^RET%,Equal,2,Begin
   Set,%Dest%,F
 End
-Else,If,#r,Equal,3,Begin
+Else,If,%^RET%,Equal,3,Begin
   Set,%Dest%,F
 End
 // Comment must not crash CodeParser by resetting the elseFlag.
-Else,If,#r,Equal,4,Begin
+Else,If,%^RET%,Equal,4,Begin
   Set,%Dest%,F
 End
-Else,If,#r,Equal,5,Begin
+Else,If,%^RET%,Equal,5,Begin
   Set,%Dest%,T
 End
 
 [Process-IfElseChain03]
 Set,%Dest%,F
-Set,#r,3
-If,#r,Equal,1,Begin
+Set,%^RET%,3
+If,%^RET%,Equal,1,Begin
   Set,%Dest%,F
 End
-Else,If,#r,Equal,2,Begin
+Else,If,%^RET%,Equal,2,Begin
   // If-Else chain with Comments
   Set,%Dest%,F
   // If-Else chain with Comments
 End
-Else,If,#r,Equal,3,Begin
+Else,If,%^RET%,Equal,3,Begin
   Set,%Dest%,T
 End
 
 [Process-NestedElseFlag-Error]
 Set,%Dest%,T
-Set,#r,2
-If,#r,Equal,1,Begin
+Set,%^RET%,2
+If,%^RET%,Equal,1,Begin
   Set,%Dest%,T
 End
-Else,Else,If,#r,Equal,2,Begin
+Else,Else,If,%^RET%,Equal,2,Begin
   Set,%Dest%,F
 End
 
 [Process-IfBeginEnd]
 Set,%Dest%,F
-Set,#r,True
-If,#r,Equal,True,Begin
+Set,%^RET%,True
+If,%^RET%,Equal,True,Begin
     Set,%Dest%,T
 End
 
 [Process-While-Simple]
 Set,%i%,0
-Set,#r,""
+Set,%^RET%,""
 While,%i%,Smaller,3,Begin
   Math,Add,%i%,%i%,1
-  Set,#r,"#rA"
+  Set,%^RET%,"%^RET%A"
  End
 
 [Process-While-If]
 Set,%A%,True
 Set,%i%,0
-Set,#r,""
+Set,%^RET%,""
 If,%A%,Equal,True,While,%i%,Smaller,3,Begin
   Math,Add,%i%,%i%,1
-  Set,#r,"#rA"
+  Set,%^RET%,"%^RET%A"
  End
  
  [Process-While-Nested]
-Set,#r,""
+Set,%^RET%,""
 Set,%A%,True
 Set,%xIdx%,0
 While,%xIdx%,Smaller,2,Begin
   Set,%yIdx%,0
   While,%yIdx%,Smaller,3,If,%A%,Equal,True,Begin
     Math,Add,%yIdx%,%yIdx%,1
-    Set,#r,"#rA"
+    Set,%^RET%,"%^RET%A"
   End
   Math,Add,%xIdx%,%xIdx%,1
 End
 
 [Process-While-Break01]
-Set,#r,""
+Set,%^RET%,""
 Set,%A%,True
 Set,%xIdx%,0
 While,%xIdx%,Smaller,2,Begin
   Set,%yIdx%,0
   While,%yIdx%,Smaller,3,Begin
     Math,Add,%yIdx%,%yIdx%,1
-    Set,#r,"#rA"
+    Set,%^RET%,"%^RET%A"
 	If,%yIdx%,Equal,2,Break
   End
   Math,Add,%xIdx%,%xIdx%,1
 End
 
 [Process-While-Break02]
-Set,#r,""
+Set,%^RET%,""
 Set,%A%,True
 Set,%xIdx%,0
 While,%xIdx%,Smaller,2,Begin
   Set,%yIdx%,0
   While,%yIdx%,Smaller,3,Begin
     Math,Add,%yIdx%,%yIdx%,1
-    Set,#r,"#rA"
+    Set,%^RET%,"%^RET%A"
   End
   Math,Add,%xIdx%,%xIdx%,1
   If,%xIdx%,Equal,1,Break
 End
 
 [Process-While-Continue01]
-Set,#r,""
+Set,%^RET%,""
 Set,%A%,True
 Set,%xIdx%,0
 While,%xIdx%,Smaller,2,Begin
@@ -266,13 +266,13 @@ While,%xIdx%,Smaller,2,Begin
   While,%yIdx%,Smaller,3,Begin
     Math,Add,%yIdx%,%yIdx%,1
 	If,%yIdx%,Bigger,2,Continue
-	Set,#r,"#rA"
+	Set,%^RET%,"%^RET%A"
   End
   Math,Add,%xIdx%,%xIdx%,1
 End
 
 [Process-While-Continue02]
-Set,#r,""
+Set,%^RET%,""
 Set,%A%,True
 Set,%xIdx%,0
 While,%xIdx%,Smaller,2,Begin
@@ -281,50 +281,50 @@ While,%xIdx%,Smaller,2,Begin
   Set,%yIdx%,0
   While,%yIdx%,Smaller,3,Begin
     Math,Add,%yIdx%,%yIdx%,1
-    Set,#r,"#rA"
+    Set,%^RET%,"%^RET%A"
   End
 End
 
 [Process-ForEach-IntList]
-Set,#r,0
+Set,%^RET%,0
 Set,%IterateList%,"1|2|4|3|7"
 ForEach,%Element%,%IterateList%,Begin
-  Math,Add,#r,#r,%Element%
+  Math,Add,%^RET%,%^RET%,%Element%
 End
 
 [Process-ForEach-StrList]
-Set,#r,""
+Set,%^RET%,""
 Set,%A%,Apple
 ForEach,%Element%,"Tomato|%A%|Orange",Begin
-  Set,#r,"#r%Element%"
+  Set,%^RET%,"%^RET%%Element%"
 End
 
 [Process-ForEach-IdxList]
-Set,#r,""
+Set,%^RET%,""
 Set,%SrcList%,"A|B|C"
 Set,%idxList%,"1?3?2"
 ForEach,%idx%,%idxList%,"Delim=?",Begin
   List,Get,%SrcList%,%idx%,%Element%
-  Set,#r,"#r%Element%"
+  Set,%^RET%,"%^RET%%Element%"
 End
 
 [Process-ForRange-Param]
-Set,#r,""
+Set,%^RET%,""
 ForRange,%i%,%Start%,%End%,%Step%,Begin
-  Set,#r,"#r%i%"
+  Set,%^RET%,"%^RET%%i%"
 End
 
 [Process-ForRangeEach-Nested]
-Set,#r,""
+Set,%^RET%,""
 Set,%SrcList%,"X|Z|Y"
 ForRange,%x%,0,4,1,Begin
   ForEach,%y%,%SrcList%,Begin
     If,%y%,Equal,Z,Continue
 	If,%x%,Equal,2,Break
-    Set,#r,#r%x%%y%
+    Set,%^RET%,%^RET%%x%%y%
   End
 End
-Set,#r,#r%y%%x%
+Set,%^RET%,%^RET%%y%%x%
 
 
 [Variables]
@@ -339,10 +339,10 @@ DelLang,"Hello"
 
 [Macro-LoopSyntaxParams-DelLang]
 ForEach,%Language%,%LangList%,Begin
-  Del,"#1_%Language%"
+  Del,"%^SIPARAM_1%_%Language%"
 End
 
 [Macro-LoopSyntaxParams-Del]
-Echo,"DEBUG: InMacro: #1"
-Set,#r,#1
+Echo,"DEBUG: InMacro: %^SIPARAM_1%"
+Set,%^RET%,%^SIPARAM_1%
 

--- a/PEBakery.Core.Tests/Samples/Projects/TestSuite/Control/General.script
+++ b/PEBakery.Core.Tests/Samples/Projects/TestSuite/Control/General.script
@@ -11,33 +11,33 @@ Mandatory=False
 %A%=1
 %B%=2
 %C%=3
-InlineMacro=Set,#r,T
+InlineMacro=Set,%^RET%,T
 
 [TestMacro]
 SectionMacro=Run,%ScriptFile%,SectionMacroImpl
-InlineMacro=Set,#r,#1
+InlineMacro=Set,%^RET%,%^SIPARAM_1%
 
 [SectionMacroImpl]
-Set,#r,#1
+Set,%^RET%,%^SIPARAM_1%
 
 [Process-SectionMacro-Global]
 AddVariables,%ScriptFile%,TestMacro,GLOBAL
-Set,#r,F
+Set,%^RET%,F
 SectionMacro,T
 
 [Process-SectionMacro-Local]
 AddVariables,%ScriptFile%,TestMacro
-Set,#r,F
+Set,%^RET%,F
 SectionMacro,T
 
 [Process-InlineMacro-Global]
 AddVariables,%ScriptFile%,TestMacro,GLOBAL
-Set,#r,F
+Set,%^RET%,F
 InlineMacro,T
 
 [Process-InlineMacro-Local]
 AddVariables,%ScriptFile%,TestMacro
-Set,#r,F
+Set,%^RET%,F
 InlineMacro,T
 
 [Process-GetParam00]
@@ -60,67 +60,67 @@ Run,%ScriptFile%,GetParam,18,""
 
 [GetParam]
 Set,%Dest%,F
-Set,%Index%,#1
+Set,%Index%,%^SIPARAM_1%
 Run,%ScriptFile%,ReadParam,P1,P2,P3,P4,P5,P6,P7,P8,P9,P10,P11,P12,P13,P14,P15,P16
-If,%Result%,Equal,#2,Set,%Dest%,T
+If,%Result%,Equal,%^SIPARAM_2%,Set,%Dest%,T
 
 [ReadParam]
 GetParam,%Index%,%Result%
 
 [Process-Exit01]
-Set,#r,T
-Exit,"##r must be T"
-Set,#r,F
+Set,%^RET%,T
+Exit,"%%^RET%% must be T"
+Set,%^RET%,F
 
 [Process-Exit02]
 System,SetLocal
-Set,#r,T
-Exit,"##r must be T"
-Set,#r,F
+Set,%^RET%,T
+Exit,"%%^RET%% must be T"
+Set,%^RET%,F
 
 [Process-Return01]
-Set,#r,INIT
+Set,%^RET%,INIT
 Run,%ScriptFile%,"Process-SubReturn-NoValue"
 Set,%Dest%,"%Dest%T"
 
 [Process-Return02]
-Set,#r,INIT
+Set,%^RET%,INIT
 Run,%ScriptFile%,"Process-SubReturn-NoValue",True
 Set,%Dest%,"%Dest%T"
 
 [Process-Return03]
-Set,#r,INIT
+Set,%^RET%,INIT
 Run,%ScriptFile%,"Process-SubReturn-WithValue"
 Set,%Dest%,"%Dest%T"
 
 [Process-Return04]
-Set,#r,INIT
+Set,%^RET%,INIT
 Run,%ScriptFile%,"Process-SubReturn-WithValue",True
 Set,%Dest%,"%Dest%T"
 
 [Process-SubReturn-NoValue]
 Set,%Dest%,T
-Set,#r,SUB
+Set,%^RET%,SUB
 Return
 Set,%Dest%,F
 
 [Process-SubReturn-WithValue]
 Set,%Dest%,T
-Set,#r,SUB
-Return,#1
+Set,%^RET%,SUB
+Return,%^SIPARAM_1%
 Set,%Dest%,F
 
 [Process-Halt-Simple]
-Set,#r,T
+Set,%^RET%,T
 Halt
-Set,#r,F
+Set,%^RET%,F
 
 [Process-Halt-InIf]
 Set,%i%,True
 If,%i%,Equal,True,Begin
-  Set,#r,T
+  Set,%^RET%,T
   Halt
-  Set,#r,F
+  Set,%^RET%,F
 End
 
 [Process-Halt-InWhile]
@@ -128,5 +128,5 @@ Set,%i%,0
 While,%i%,Smaller,4,Begin
   If,%i%,Equal,2,Halt
   Math,Add,%i%,%i%,1
-  Set,#r,"#rA"
+  Set,%^RET%,"%^RET%A"
  End

--- a/PEBakery.Core.Tests/Samples/Projects/TestSuite/Macro/General.script
+++ b/PEBakery.Core.Tests/Samples/Projects/TestSuite/Macro/General.script
@@ -8,7 +8,7 @@ Selected=True
 Mandatory=False
 
 [Variables]
-InlineMacro=Set,#r,#1
+InlineMacro=Set,%^RET%,%^SIPARAM_1%
 SectionMacro=Run,%ScriptFile%,SectionMacroImpl
 CondMacro01=Run,%ScriptFile%,CondMacroImpl01
 CondMacro02=Run,%ScriptFile%,CondMacroImpl02
@@ -16,51 +16,51 @@ PhoenixMacro=Run,%ScriptFile%,PhoenixMacroImpl
 SetLocalParamsMacro=Run,%ScriptFile%,SetLocalParamsMacroImpl
 
 [SectionMacroImpl]
-Set,#r,#1
+Set,%^RET%,%^SIPARAM_1%
 
 [CondMacroImpl01]
-Set,#r,0
-If,#1,Equal,True,Begin
-  Set,#r,T
+Set,%^RET%,0
+If,%^SIPARAM_1%,Equal,True,Begin
+  Set,%^RET%,T
 End
 Else,Begin
-  Set,#r,F
+  Set,%^RET%,F
 End
 
 [CondMacroImpl02]
-Set,#r,0
-If,#1,Equal,True,Set,#r,F
-Else,Set,#r,F
-Set,#r,T
+Set,%^RET%,0
+If,%^SIPARAM_1%,Equal,True,Set,%^RET%,F
+Else,Set,%^RET%,F
+Set,%^RET%,T
 
 [PhoenixMacroImpl]
 System,SetLocal
-Set,#r,F
-If,#1,Equal,"",Exit,"Syntax Error"
-If,#2,Equal,"",Exit,"Syntax Error"
-If,#3,Equal,"",Exit,"Syntax Error"
+Set,%^RET%,F
+If,%^SIPARAM_1%,Equal,"",Exit,"Syntax Error"
+If,%^SIPARAM_2%,Equal,"",Exit,"Syntax Error"
+If,%^SIPARAM_3%,Equal,"",Exit,"Syntax Error"
 GetParam,1,%A%
 GetParam,2,%B%
 GetParam,3,%C%
-If,#1,Equal,True,Begin
-  If,#2,Equal,0,Set,#r,0
-  Else,If,#2,Equal,1,Set,#r,1
-  Else,If,#2,Equal,2,Set,#r,2
-  Else,If,#2,Equal,3,Set,#r,3
+If,%^SIPARAM_1%,Equal,True,Begin
+  If,%^SIPARAM_2%,Equal,0,Set,%^RET%,0
+  Else,If,%^SIPARAM_2%,Equal,1,Set,%^RET%,1
+  Else,If,%^SIPARAM_2%,Equal,2,Set,%^RET%,2
+  Else,If,%^SIPARAM_2%,Equal,3,Set,%^RET%,3
   Else,Exit,"Syntax Error"
   
-  If,#3,Equal,T,Set,#r,A
-  Else,If,#3,Equal,F,Set,#r,B
+  If,%^SIPARAM_3%,Equal,T,Set,%^RET%,A
+  Else,If,%^SIPARAM_3%,Equal,F,Set,%^RET%,B
   // The comment between If and Else had crashed CodeParser.FoldBranchCodeBlock() method in the past. 
   Else,Halt,"Syntax Error"
 End
 Else,Begin
-  If,#3,Equal,T,Set,#r,X
-  Else,If,#3,Equal,F,Set,#r,Y
+  If,%^SIPARAM_3%,Equal,T,Set,%^RET%,X
+  Else,If,%^SIPARAM_3%,Equal,F,Set,%^RET%,Y
   // The bug was reported by @homes32, and investigated and fixed by @ied206.
   Else,Halt,"Syntax Error"
 End
-Set,#r,T
+Set,%^RET%,T
 System,EndLocal
 
 [SetLocalParamsMacroImpl]
@@ -69,32 +69,32 @@ GetParam,1,%A%
 GetParam,2,%B%
 GetParam,3,%C%
 GetParam,4,%D%
-If,%D%,Equal,"A/B/C",Set,#r,"T"
+If,%D%,Equal,"A/B/C",Set,%^RET%,"T"
 System,EndLocal
 
 [Process-InlineMacro]
 AddVariables,%ScriptFile%,Variables
-Set,#r,F
+Set,%^RET%,F
 InlineMacro,T
 
 [Process-SectionMacro]
 AddVariables,%ScriptFile%,Variables
-Set,#r,F
+Set,%^RET%,F
 SectionMacro,T
 
 [Process-CondMacro01]
 AddVariables,%ScriptFile%,Variables
-Set,#r,F
+Set,%^RET%,F
 CondMacro01,True
 
 [Process-CondMacro02]
 AddVariables,%ScriptFile%,Variables
-Set,#r,F
+Set,%^RET%,F
 CondMacro02,True
 
 [Process-PhoenixMacro]
 AddVariables,%ScriptFile%,Variables
-Set,#r,F
+Set,%^RET%,F
 PhoenixMacro,True,3,T
 
 [Process-SetLocalParamsMacro]
@@ -102,5 +102,5 @@ AddVariables,%ScriptFile%,Variables
 Set,%A%,"A"
 Set,%B%,"B"
 Set,%C%,"C"
-Set,#r,"F"
+Set,%^RET%,"F"
 SetLocalParamsMacro,"X","Y","Z","%A%/%B%/%C%"

--- a/PEBakery.Core.Tests/Samples/Projects/TestSuite/System/SetEndLocal.script
+++ b/PEBakery.Core.Tests/Samples/Projects/TestSuite/System/SetEndLocal.script
@@ -10,31 +10,31 @@ Mandatory=False
 [Process-Simple]
 Set,%Dest%,0
 Run,%ScriptFile%,Simple-Depth1
-Echo,#r
+Echo,%^RET%
 
 [Simple-Depth1]
 System,SetLocal
 Set,%Dest%,1
-Set,#r,A
+Set,%^RET%,A
 Run,%ScriptFile%,Simple-Depth2,B
 System,EndLocal
 
 [Simple-Depth2]
 System,SetLocal
-Set,%Dest%,#1
-Set,#r,#1
+Set,%Dest%,%^SIPARAM_1%
+Set,%^RET%,%^SIPARAM_1%
 System,EndLocal
 
 [Process-Branch]
 Set,%Dest%,0
 Run,%ScriptFile%,Branch-Depth1,True
-Echo,#r
+Echo,%^RET%
 
 [Branch-Depth1]
 System,SetLocal
-If,#1,Equal,True,Begin
+If,%^SIPARAM_1%,Equal,True,Begin
   Set,%Dest%,1
-  Set,#r,A
+  Set,%^RET%,A
   Run,%ScriptFile%,Branch-Depth2,False,B
 End
 Else,Begin
@@ -44,24 +44,24 @@ System,EndLocal
 
 [Branch-Depth2]
 System,SetLocal
-If,#1,Equal,True,Begin
+If,%^SIPARAM_1%,Equal,True,Begin
   Echo,"Do Nothing"
 End
 Else,Begin
-  Set,%Dest%,#2
-  Set,#r,#2
+  Set,%Dest%,%^SIPARAM_2%
+  Set,%^RET%,%^SIPARAM_2%
 End
 System,EndLocal
 
 [Process-ImplicitEnd]
 Set,%Dest%,0
 Run,%ScriptFile%,ImplicitEnd-Depth1,True
-Echo,#r
+Echo,%^RET%
 
 [ImplicitEnd-Depth1]
-If,#1,Equal,True,Begin
+If,%^SIPARAM_1%,Equal,True,Begin
   System,SetLocal
   Set,%Dest%,1
-  Set,#r,A
+  Set,%^RET%,A
 End
 Set,%Dest%,-1

--- a/PEBakery.Core.Tests/StringEscaperTests.cs
+++ b/PEBakery.Core.Tests/StringEscaperTests.cs
@@ -249,6 +249,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandSectionParams_1()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 1);
 
             s.Variables.SetValue(VarsType.Local, "A", "Hello");
@@ -263,6 +264,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandSectionParams_2()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 1);
 
             Variables.SetVariable(s, "#1", "World");
@@ -276,6 +278,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandSectionParams_3()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 1);
 
             s.Variables.SetValue(VarsType.Local, "A", "Hello");
@@ -289,6 +292,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandSectionParams_4()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 2);
 
             s.Variables.SetValue(VarsType.Local, "A", "Hello");
@@ -302,6 +306,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandSectionParams_5()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 2);
 
             s.Variables.SetValue(VarsType.Local, "B", "C#");
@@ -330,6 +335,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandSectionParams_6()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 2);
 
             s.Variables.SetValue(VarsType.Local, "A", "Hello");
@@ -347,6 +353,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandSectionParams_7()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 1);
             s.ReturnValue = "TEST";
 
@@ -361,6 +368,14 @@ namespace PEBakery.Core.Tests
         [TestMethod]
         public void ExpandPercentPatternSectionParams()
         {
+            ExpandPercentPatternSectionParams_1();
+            ExpandPercentPatternSectionParams_2();
+            ExpandPercentPatternSectionParams_3();
+            ExpandPercentPatternSectionParams_4();
+        }
+
+        public static void ExpandPercentPatternSectionParams_1()
+        {
             EngineState s = EngineTests.CreateEngineState();
             EngineTests.PushDepthInfo(s, 1);
 
@@ -371,6 +386,59 @@ namespace PEBakery.Core.Tests
             string dest = StringEscaper.ExpandPercentPatternSectionParams(s, src);
             const string comp = "%A% #1 World";
             Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
+        }
+
+        public static void ExpandPercentPatternSectionParams_2()
+        {
+            EngineState s = EngineTests.CreateEngineState();
+            EngineTests.PushDepthInfo(s, 2);
+
+            s.CurSectionInParams[1] = "One";
+            s.CurSectionInParams[2] = "Two";
+
+            const string src = "[%^SIPARAM_1%]|[%^SIPARAM_2%]|[%^SIPARAM_3%]|%^SIPARAM_COUNT%";
+            string dest = StringEscaper.ExpandPercentPatternSectionParams(s, src);
+            const string comp = "[One]|[Two]|[]|2";
+            Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
+        }
+
+        public static void ExpandPercentPatternSectionParams_3()
+        {
+            EngineState s = EngineTests.CreateEngineState();
+            s.CurSectionOutParams = ["%DestOne%", "%DestTwo%"];
+            s.Variables.SetValue(VarsType.Local, "DestOne", "One");
+            s.Variables.SetValue(VarsType.Local, "DestTwo", "Two");
+
+            const string src = "[%^SOPARAM_1%]|[%^SOPARAM_2%]|[%^SOPARAM_3%]|%^SOPARAM_COUNT%";
+            string dest = StringEscaper.ExpandPercentPatternSectionParams(s, src);
+            const string comp = "[One]|[Two]|[]|2";
+            Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
+        }
+
+        public static void ExpandPercentPatternSectionParams_4()
+        {
+            EngineState s = EngineTests.CreateEngineState();
+            s.ReturnValue = "Done";
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState(42));
+
+            const string indexSrc = "%^RET%|%^LOOP_IDX%";
+            string indexDest = StringEscaper.ExpandPercentPatternSectionParams(s, indexSrc);
+            const string indexComp = "Done|42";
+            Assert.IsTrue(indexDest.Equals(indexComp, StringComparison.Ordinal));
+
+            s.LoopCmdStateStack.Clear();
+            s.LoopCmdStateStack.Push(new EngineLoopCmdState('Z'));
+
+            const string letterSrc = "%^LOOP_IDX%";
+            string letterDest = StringEscaper.ExpandPercentPatternSectionParams(s, letterSrc);
+            const string letterComp = "Z";
+            Assert.IsTrue(letterDest.Equals(letterComp, StringComparison.Ordinal));
+
+            s.LoopCmdStateStack.Clear();
+
+            const string noLoopSrc = "%^LOOP_IDX%";
+            string noLoopDest = StringEscaper.ExpandPercentPatternSectionParams(s, noLoopSrc);
+            Assert.IsTrue(string.Empty.Equals(noLoopDest, StringComparison.Ordinal));
         }
         #endregion
 
@@ -384,11 +452,13 @@ namespace PEBakery.Core.Tests
             ExpandVariables_4();
             ExpandVariables_5();
             ExpandVariables_6();
+            ExpandVariables_7();
         }
 
         public static void ExpandVariables_1()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
 
             s.Variables.SetValue(VarsType.Local, "A", "Hello");
             s.CurSectionInParams[1] = "World";
@@ -402,6 +472,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandVariables_2()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             s.CurSectionInParams[1] = "World";
 
             const string src = "%A% #1";
@@ -413,6 +484,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandVariables_3()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 1);
 
             s.Variables.SetValue(VarsType.Local, "A", "Hello");
@@ -426,6 +498,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandVariables_4()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 2);
 
             s.Variables.SetValue(VarsType.Local, "A", "Hello");
@@ -439,6 +512,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandVariables_5()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 2);
 
             s.Variables.SetValue(VarsType.Local, "B", "C#");
@@ -467,6 +541,7 @@ namespace PEBakery.Core.Tests
         public static void ExpandVariables_6()
         {
             EngineState s = EngineTests.CreateEngineState();
+            s.CompatEnableAllLegacySectionParams = true;
             EngineTests.PushDepthInfo(s, 2);
 
             // In real world, a value must be set with SetValue, so circular reference of variables does not happen 
@@ -480,6 +555,19 @@ namespace PEBakery.Core.Tests
             catch (InvalidOperationException) { return; }
 
             Assert.Fail();
+        }
+
+        public static void ExpandVariables_7()
+        {
+            EngineState s = EngineTests.CreateEngineState();
+
+            s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            Variables.SetVariable(s, "%^SIPARAM_1%", "World");
+
+            const string src = "%A% %^SIPARAM_1% #1";
+            string dest = StringEscaper.ExpandVariables(s, src);
+            const string comp = "Hello World #1";
+            Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
         }
         #endregion
 
@@ -565,7 +653,7 @@ namespace PEBakery.Core.Tests
                 s.Variables.SetValue(VarsType.Local, "A", "Hello");
             });
 
-            SingleTemplate("%A% %^SIPARAM_1%", "Hello %^SIPARAM_1%", s =>
+            SingleTemplate("%A% %^SIPARAM_1%", "Hello ", s =>
             {
                 EngineTests.PushDepthInfo(s, 1);
                 s.Variables.SetValue(VarsType.Local, "A", "Hello");
@@ -579,7 +667,7 @@ namespace PEBakery.Core.Tests
                 s.Variables.SetValue(VarsType.Local, "A", "Hello");
             });
 
-            SingleTemplate("%A% #1", "Hello ", s =>
+            SingleTemplate("%A% #1", "Hello #1", s =>
             {
                 s.CompatEnableAllLegacySectionParams = false;
                 EngineTests.PushDepthInfo(s, 2);
@@ -600,7 +688,7 @@ namespace PEBakery.Core.Tests
                 s.Variables.SetValue(VarsType.Local, "A", "Hello");
             });
 
-            SingleTemplate("%A% #1", "Hello ", s =>
+            SingleTemplate("%A% #1", "Hello #1", s =>
             {
                 s.CompatEnableAllLegacySectionParams = false;
                 EngineTests.PushDepthInfo(s, 2);
@@ -641,8 +729,8 @@ namespace PEBakery.Core.Tests
             ], [
                 "A_%A%",
                 "B_C#",
-                "C_",
-                "D_WPF"
+                "C_#1",
+                "D_#2"
             ], s =>
             {
                 s.CompatEnableAllLegacySectionParams = false;

--- a/PEBakery.Core.Tests/StringEscaperTests.cs
+++ b/PEBakery.Core.Tests/StringEscaperTests.cs
@@ -356,6 +356,23 @@ namespace PEBakery.Core.Tests
         }
         #endregion
 
+        #region ExpandPercentPatternSectionParams
+        [TestMethod]
+        public void ExpandPercentPatternSectionParams()
+        {
+            EngineState s = EngineTests.CreateEngineState();
+            EngineTests.PushDepthInfo(s, 1);
+
+            s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            s.CurSectionInParams[1] = "World";
+
+            const string src = "%A% #1 %^SPARAM_1%";
+            string dest = StringEscaper.ExpandPercentPatternSectionParams(s, src);
+            const string comp = "%A% #1 World";
+            Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
+        }
+        #endregion
+
         #region ExpandVariables
         [TestMethod]
         public void ExpandVariables()

--- a/PEBakery.Core.Tests/StringEscaperTests.cs
+++ b/PEBakery.Core.Tests/StringEscaperTests.cs
@@ -30,6 +30,7 @@ using PEBakery.Helper;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -52,17 +53,17 @@ namespace PEBakery.Core.Tests
 
             // Overload of IEnumerable<string>
             string[] srcStrs =
-            {
+            [
                 "Comma [,]",
                 "Space [ ]",
                 "DoubleQuote [\"]"
-            };
+            ];
             string[] comps =
-            {
+            [
                "Comma#$s[#$c]",
                "Space#$s[#$s]",
                "DoubleQuote#$s[#$q]",
-            };
+            ];
             EscapeArrayTemplate(srcStrs, true, false, comps);
 
             // #$x issue
@@ -92,13 +93,13 @@ namespace PEBakery.Core.Tests
             // SampleString
             QuoteEscapeTemplate(SampleString, false, false, "\"Comma [,]#$xPercent [%]#$xDoubleQuote [#$q]#$xSpace [ ]#$xTab [#$t]#$xSharp [##]#$xNewLine [#$x]\"");
 
-            string[] srcs = new string[] { "Comma [,]", "Space [ ]", "DoubleQuote [\"]" };
-            string[] expects = new string[]
-            {
+            string[] srcs = ["Comma [,]", "Space [ ]", "DoubleQuote [\"]"];
+            string[] expects =
+            [
                "\"Comma [,]\"",
                "\"Space [ ]\"",
                "\"DoubleQuote [#$q]\"",
-            };
+            ];
             QuoteEscapeArrayTemplate(srcs, false, false, expects);
         }
 
@@ -126,18 +127,18 @@ namespace PEBakery.Core.Tests
             UnescapeTemplate("Comma#$s[#$c]#$xPercent#$s[#$p]#$xDoubleQuote#$s[#$q]#$xSpace#$s[#$s]#$xTab#$s[#$t]#$xSharp#$s[##]#$xNewLine#$s[#$x]", true, SampleString);
             UnescapeTemplate("Incomplete#$", false, "Incomplete#$");
 
-            string[] srcs = new string[]
-            {
+            string[] srcs =
+            [
                "Comma#$s[#$c]",
                "Space#$s[#$s]",
                "DoubleQuote#$s[#$q]",
-            };
-            string[] expects = new string[]
-            {
+            ];
+            string[] expects =
+            [
                 "Comma [,]",
                 "Space [ ]",
                 "DoubleQuote [\"]",
-            };
+            ];
             UnescapeArrayTemplate(srcs, false, expects);
         }
 
@@ -161,18 +162,18 @@ namespace PEBakery.Core.Tests
         {
             QuoteUnescapeTemplate("\"Comma [,]#$xPercent [%]#$xDoubleQuote [#$q]#$xSpace [ ]#$xTab [#$t]#$xSharp [##]#$xNewLine [#$x]\"", false, SampleString);
 
-            string[] srcs = new string[]
-            {
+            string[] srcs =
+            [
                "\"Comma [#$c]\"",
                "\"Space [ ]\"",
                "\"DoubleQuote [#$q]\"",
-            };
-            string[] expects = new string[]
-            {
+            ];
+            string[] expects =
+            [
                 "Comma [,]",
                 "Space [ ]",
                 "DoubleQuote [\"]",
-            };
+            ];
             QuoteUnescapeArrayTemplate(srcs, false, expects);
         }
 
@@ -203,12 +204,12 @@ namespace PEBakery.Core.Tests
             EscapeThenUnescapeTemplate(SampleString, true, true);
             EscapeThenUnescapeTemplate("Hello#$xWorld", false, false);
 
-            string[] srcs = new string[]
-            {
+            string[] srcs =
+            [
                "\"Comma [#$c]\"",
                "\"Space [ ]\"",
                "\"DoubleQuote [#$q]\"",
-            };
+            ];
             EscapeThenUnescapeArrayTemplate(srcs, false, false);
             EscapeThenUnescapeArrayTemplate(srcs, true, false);
             EscapeThenUnescapeArrayTemplate(srcs, false, true);
@@ -307,20 +308,20 @@ namespace PEBakery.Core.Tests
             Variables.SetVariable(s, "#2", "WPF");
 
             string[] srcs =
-            {
+            [
                 "A_%A%",
                 "B_%B%",
                 "C_#1",
                 "D_#2"
-            };
+            ];
             List<string> dests = StringEscaper.ExpandSectionParams(s, srcs);
             string[] comps =
-            {
+            [
                 "A_%A%",
                 "B_%B%",
                 "C_",
                 "D_WPF"
-            };
+            ];
 
             for (int i = 0; i < dests.Count; i++)
                 Assert.IsTrue(dests[i].Equals(comps[i], StringComparison.Ordinal));
@@ -366,7 +367,7 @@ namespace PEBakery.Core.Tests
             s.Variables.SetValue(VarsType.Local, "A", "Hello");
             s.CurSectionInParams[1] = "World";
 
-            const string src = "%A% #1 %^SPARAM_1%";
+            const string src = "%A% #1 %^SIPARAM_1%";
             string dest = StringEscaper.ExpandPercentPatternSectionParams(s, src);
             const string comp = "%A% #1 World";
             Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
@@ -444,20 +445,20 @@ namespace PEBakery.Core.Tests
             s.CurSectionInParams[2] = "WPF";
 
             string[] srcs =
-            {
+            [
                 "A_%A%",
                 "B_%B%",
                 "C_#1",
                 "D_#2"
-            };
+            ];
             List<string> dests = StringEscaper.ExpandVariables(s, srcs);
             string[] comps =
-            {
+            [
                 "A_#$pA#$p",
                 "B_C#",
                 "C_",
                 "D_WPF"
-            };
+            ];
 
             for (int i = 0; i < dests.Count; i++)
                 Assert.IsTrue(dests[i].Equals(comps[i], StringComparison.Ordinal));
@@ -486,109 +487,234 @@ namespace PEBakery.Core.Tests
         [TestMethod]
         public void Preprocess()
         {
-            Preprocess_1();
-            Preprocess_2();
-            Preprocess_3();
-            Preprocess_4();
-            Preprocess_5();
-            Preprocess_6();
-        }
-
-        public static void Preprocess_1()
-        {
-            EngineState s = EngineTests.CreateEngineState();
-            s.Variables.SetValue(VarsType.Local, "A", "Hello");
-            Variables.SetVariable(s, "#1", "World");
-
-            const string src = "%A% #1";
-            string dest = StringEscaper.Preprocess(s, src);
-            const string comp = "Hello World";
-            Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
-        }
-
-        public static void Preprocess_2()
-        {
-            EngineState s = EngineTests.CreateEngineState();
-            Variables.SetVariable(s, "#1", "World");
-
-            const string src = "%A% #1";
-            string dest = StringEscaper.Preprocess(s, src);
-            const string comp = "%A% World";
-            Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
-        }
-
-        public static void Preprocess_3()
-        {
-            EngineState s = EngineTests.CreateEngineState();
-            EngineTests.PushDepthInfo(s, 1);
-
-            s.Variables.SetValue(VarsType.Local, "A", "Hello");
-
-            const string src = "%A% #1";
-            string dest = StringEscaper.Preprocess(s, src);
-            const string comp = "Hello #1";
-            Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
-        }
-
-        public static void Preprocess_4()
-        {
-            EngineState s = EngineTests.CreateEngineState();
-            EngineTests.PushDepthInfo(s, 2);
-
-            s.Variables.SetValue(VarsType.Local, "A", "Hello");
-
-            const string src = "%A% #1";
-            string dest = StringEscaper.Preprocess(s, src);
-            const string comp = "Hello ";
-            Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
-        }
-
-        public static void Preprocess_5()
-        {
-            EngineState s = EngineTests.CreateEngineState();
-            EngineTests.PushDepthInfo(s, 2);
-
-            s.Variables.SetValue(VarsType.Local, "B", "C#");
-            Variables.SetVariable(s, "#2", "WPF");
-
-            string[] srcs =
+            static EngineState SingleTemplate(string src, string expected, Action<EngineState>? setEnvAction)
             {
+                EngineState s = EngineTests.CreateEngineState();
+                setEnvAction?.Invoke(s);
+
+                string dest = StringEscaper.Preprocess(s, src);
+                Assert.IsTrue(expected.Equals(dest, StringComparison.Ordinal));
+
+                return s;
+            }
+
+            static EngineState MultiTemplate(string[] srcs, string[] expecteds, Action<EngineState>? setEnvAction)
+            {
+                EngineState s = EngineTests.CreateEngineState();
+                setEnvAction?.Invoke(s);
+
+                List<string> dests = StringEscaper.Preprocess(s, srcs);
+
+                for (int i = 0; i < dests.Count; i++)
+                    Assert.IsTrue(dests[i].Equals(expecteds[i], StringComparison.Ordinal));
+
+                return s;
+            }
+
+
+            SingleTemplate("%A% #1", "Hello World", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = true;
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+                Variables.SetVariable(s, "#1", "World");
+            });
+
+            SingleTemplate("%A% #1", "Hello #1", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = false;
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+                Variables.SetVariable(s, "#1", "World");
+            });
+
+            SingleTemplate("%A% %^SIPARAM_1%", "Hello World", s =>
+            {
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+                Variables.SetVariable(s, "%^SIPARAM_1%", "World");
+            });
+
+
+            SingleTemplate("%A% #1", "%A% World", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = true;
+                Variables.SetVariable(s, "#1", "World");
+            });
+
+            SingleTemplate("%A% #1", "%A% #1", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = false;
+                Variables.SetVariable(s, "#1", "World");
+            });
+
+            SingleTemplate("%A% %^SIPARAM_1%", "%A% World", s =>
+            {
+                Variables.SetVariable(s, "%^SIPARAM_1%", "World");
+            });
+
+            
+            SingleTemplate("%A% #1", "Hello #1", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = true;
+                EngineTests.PushDepthInfo(s, 1);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+            SingleTemplate("%A% #1", "Hello #1", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = false;
+                EngineTests.PushDepthInfo(s, 1);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+            SingleTemplate("%A% %^SIPARAM_1%", "Hello %^SIPARAM_1%", s =>
+            {
+                EngineTests.PushDepthInfo(s, 1);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+
+            SingleTemplate("%A% #1", "Hello ", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = true;
+                EngineTests.PushDepthInfo(s, 2);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+            SingleTemplate("%A% #1", "Hello ", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = false;
+                EngineTests.PushDepthInfo(s, 2);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+            SingleTemplate("%A% %^SIPARAM_1%", "Hello ", s =>
+            {
+                EngineTests.PushDepthInfo(s, 2);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+
+            SingleTemplate("%A% #1", "Hello ", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = true;
+                EngineTests.PushDepthInfo(s, 2);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+            SingleTemplate("%A% #1", "Hello ", s =>
+            {
+                s.CompatEnableAllLegacySectionParams = false;
+                EngineTests.PushDepthInfo(s, 2);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+            SingleTemplate("%A% %^SIPARAM_1%", "Hello ", s =>
+            {
+                EngineTests.PushDepthInfo(s, 2);
+                s.Variables.SetValue(VarsType.Local, "A", "Hello");
+            });
+
+
+            MultiTemplate([
                 "A_%A%",
                 "B_%B%",
                 "C_#1",
                 "D_#2"
-            };
-            List<string> dests = StringEscaper.Preprocess(s, srcs);
-            string[] comps =
-            {
+            ], [
                 "A_%A%",
                 "B_C#",
                 "C_",
                 "D_WPF"
-            };
+            ], s =>
+            {
+                s.CompatEnableAllLegacySectionParams = true;
+                EngineTests.PushDepthInfo(s, 2);
 
-            for (int i = 0; i < dests.Count; i++)
-                Assert.IsTrue(dests[i].Equals(comps[i], StringComparison.Ordinal));
-        }
+                s.Variables.SetValue(VarsType.Local, "B", "C#");
+                Variables.SetVariable(s, "#2", "WPF");
+            });
 
-        public static void Preprocess_6()
-        {
-            EngineState s = EngineTests.CreateEngineState();
-            EngineTests.PushDepthInfo(s, 2);
+            MultiTemplate([
+                "A_%A%",
+                "B_%B%",
+                "C_#1",
+                "D_#2"
+            ], [
+                "A_%A%",
+                "B_C#",
+                "C_",
+                "D_WPF"
+            ], s =>
+            {
+                s.CompatEnableAllLegacySectionParams = false;
+                EngineTests.PushDepthInfo(s, 2);
 
-            // In real world, a value must be set with SetVariables, so circular reference of variables does not happen 
-            s.Variables.SetValue(VarsType.Local, "A", "%B%");
-            s.Variables.SetValue(VarsType.Local, "B", "%C%");
-            s.Variables.SetValue(VarsType.Local, "C", "%A%");
-            Variables.SetVariable(s, "#1", "#2");
-            Variables.SetVariable(s, "#2", "#3");
-            Variables.SetVariable(s, "#3", "#1");
+                s.Variables.SetValue(VarsType.Local, "B", "C#");
+                Variables.SetVariable(s, "#2", "WPF");
+            });
 
-            const string src = "%A% #1";
-            try { StringEscaper.Preprocess(s, src); }
-            catch (InvalidOperationException) { return; }
+            MultiTemplate([
+                "A_%A%",
+                "B_%B%",
+                "C_%^SIPARAM_1%",
+                "D_%^SIPARAM_2%"
+            ], [
+                "A_%A%",
+                "B_C#",
+                "C_",
+                "D_WPF"
+            ], s =>
+            {
+                EngineTests.PushDepthInfo(s, 2);
 
-            Assert.Fail();
+                s.Variables.SetValue(VarsType.Local, "B", "C#");
+                Variables.SetVariable(s, "%^SIPARAM_2%", "WPF");
+            });
+
+
+            // Circular Reference Tests
+            do
+            {
+                EngineState s = EngineTests.CreateEngineState();
+                s.CompatEnableAllLegacySectionParams = true;
+                EngineTests.PushDepthInfo(s, 2);
+
+                // In real world, a value must be set with SetVariables, so circular reference of variables does not happen 
+                s.Variables.SetValue(VarsType.Local, "A", "%B%");
+                s.Variables.SetValue(VarsType.Local, "B", "%C%");
+                s.Variables.SetValue(VarsType.Local, "C", "%A%");
+                Variables.SetVariable(s, "#1", "#2");
+                Variables.SetVariable(s, "#2", "#3");
+                Variables.SetVariable(s, "#3", "#1");
+
+                const string src = "%A% #1";
+                try { StringEscaper.Preprocess(s, src); }
+                catch (InvalidOperationException) { break; }
+
+                Assert.Fail();
+            }
+            while (false);
+
+            do
+            {
+                EngineState s = EngineTests.CreateEngineState();
+                s.CompatEnableAllLegacySectionParams = false;
+                EngineTests.PushDepthInfo(s, 2);
+
+                // In real world, a value must be set with SetVariables, so circular reference of variables does not happen 
+                s.Variables.SetValue(VarsType.Local, "A", "%B%");
+                s.Variables.SetValue(VarsType.Local, "B", "%C%");
+                s.Variables.SetValue(VarsType.Local, "C", "%A%");
+                Variables.SetVariable(s, "%^SIPARAM_1%", "#2");
+                Variables.SetVariable(s, "%^SIPARAM_2%", "#3");
+                Variables.SetVariable(s, "%^SIPARAM_3%", "#1");
+
+                const string src = "%A% #1";
+                try { StringEscaper.Preprocess(s, src); }
+                catch (InvalidOperationException) { break; }
+
+                Assert.Fail();
+            }
+            while (false);
         }
         #endregion
 
@@ -743,7 +869,7 @@ namespace PEBakery.Core.Tests
 
         public static void PackRegBinary_2()
         {
-            byte[] src = new byte[] { 0x43, 0x00, 0x3A, 0x00, 0x5C, 0x00 };
+            byte[] src = [0x43, 0x00, 0x3A, 0x00, 0x5C, 0x00];
             string dest = StringEscaper.PackRegBinary(src);
             string comp = "43,00,3A,00,5C,00";
             Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
@@ -761,7 +887,7 @@ namespace PEBakery.Core.Tests
         {
             string src = "43,00,3A,00,5C,00";
             Assert.IsTrue(StringEscaper.UnpackRegBinary(src, out byte[] dest));
-            byte[] comp = new byte[] { 0x43, 0x00, 0x3A, 0x00, 0x5C, 0x00 };
+            byte[] comp = [0x43, 0x00, 0x3A, 0x00, 0x5C, 0x00];
             for (int i = 0; i < dest.Length; i++)
                 Assert.IsTrue(dest[i] == comp[i]);
         }
@@ -776,12 +902,12 @@ namespace PEBakery.Core.Tests
 
         public static void PackRegMultiBinary_1()
         {
-            string[] src = new string[]
-            {
+            string[] src =
+            [
                 "C:\\",
                 "Hello",
                 "World",
-            };
+            ];
             string dest = StringEscaper.PackRegMultiBinary(src);
             string comp = "43,00,3A,00,5C,00,00,00,48,00,65,00,6C,00,6C,00,6F,00,00,00,57,00,6F,00,72,00,6C,00,64,00";
             Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
@@ -793,11 +919,11 @@ namespace PEBakery.Core.Tests
         public void PackRegMultiString()
         {
             string[] src =
-            {
+            [
                 "C:\\",
                 "Hello",
                 "World",
-            };
+            ];
             string dest = StringEscaper.PackRegMultiString(src);
             const string comp = "C:\\#$zHello#$zWorld";
             Assert.IsTrue(dest.Equals(comp, StringComparison.Ordinal));
@@ -811,11 +937,11 @@ namespace PEBakery.Core.Tests
             const string src = "C:\\#$zHello#$zWorld";
             List<string> dests = StringEscaper.UnpackRegMultiString(src);
             string[] comps =
-            {
+            [
                 "C:\\",
                 "Hello",
                 "World",
-            };
+            ];
 
             for (int i = 0; i < dests.Count; i++)
                 Assert.IsTrue(dests[i].Equals(comps[i], StringComparison.Ordinal));

--- a/PEBakery.Core/CodeParser.cs
+++ b/PEBakery.Core/CodeParser.cs
@@ -2548,7 +2548,8 @@ namespace PEBakery.Core
                         {
                             case Variables.VarKeyType.Variable:
                                 break;
-                            case Variables.VarKeyType.SectionInParams:
+                            case Variables.VarKeyType.SectionInParamsPercent:
+                            case Variables.VarKeyType.SectionInParamsLegacy:
                                 throw new InvalidCommandException($"Section parameter [{args[1]}] cannot be used in GetParam", rawCode);
                             default:
                                 throw new InvalidCommandException($"[{args[1]}] is not a valid variable name", rawCode);
@@ -2568,8 +2569,9 @@ namespace PEBakery.Core
                         {
                             case Variables.VarKeyType.Variable:
                                 break;
-                            case Variables.VarKeyType.SectionInParams:
-                                throw new InvalidCommandException($"Section parameter [{args[1]}] cannot be used in GetParam", rawCode);
+                            case Variables.VarKeyType.SectionInParamsPercent:
+                            case Variables.VarKeyType.SectionInParamsLegacy:
+                                throw new InvalidCommandException($"Section parameter [{args[1]}] cannot be used in PackParam", rawCode);
                             default:
                                 throw new InvalidCommandException($"[{args[1]}] is not a valid variable name", rawCode);
                         }
@@ -2583,8 +2585,9 @@ namespace PEBakery.Core
                                 case Variables.VarKeyType.Variable:
                                     varCount = args[2];
                                     break;
-                                case Variables.VarKeyType.SectionInParams:
-                                    throw new InvalidCommandException($"Section parameter [{args[2]}] cannot be used in GetParam", rawCode);
+                                case Variables.VarKeyType.SectionInParamsPercent:
+                                case Variables.VarKeyType.SectionInParamsLegacy:
+                                    throw new InvalidCommandException($"Section parameter [{args[2]}] cannot be used in PackParam", rawCode);
                                 default:
                                     throw new InvalidCommandException($"[{args[2]}] is not a valid variable name", rawCode);
                             }
@@ -4545,8 +4548,8 @@ namespace PEBakery.Core
         public static bool StringContainsVariable(string str)
         {
             MatchCollection matches = Regex.Matches(str, Variables.VarKeyRegexContainsVariable, RegexOptions.Compiled | RegexOptions.CultureInvariant); // ABC%Joveler%
-            bool sectionInParamMatch = Regex.IsMatch(str, Variables.VarKeyRegexContainsSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #1
-            bool sectionOutParamMatch = Regex.IsMatch(str, Variables.VarKeyRegexContainsSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #o1
+            bool sectionInParamMatch = Regex.IsMatch(str, Variables.VarKeyRegexContainsLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #1
+            bool sectionOutParamMatch = Regex.IsMatch(str, Variables.VarKeyRegexContainsLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #o1
             bool sectionLoopMatch = str.IndexOf("#c", StringComparison.OrdinalIgnoreCase) != -1; // #c
             bool sectionInParamCountMatch = str.IndexOf("#a", StringComparison.OrdinalIgnoreCase) != -1; // #a
             bool sectionOutParamCountMatch = str.IndexOf("#oa", StringComparison.OrdinalIgnoreCase) != -1; // #oa
@@ -4568,11 +4571,11 @@ namespace PEBakery.Core
             if (0 < matches.Count)
                 refSet.Add(matches[0].Value);
 
-            matches = Regex.Matches(str, Variables.VarKeyRegexContainsSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #1
+            matches = Regex.Matches(str, Variables.VarKeyRegexContainsLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #1
             if (0 < matches.Count)
                 refSet.Add(matches[0].Value);
 
-            matches = Regex.Matches(str, Variables.VarKeyRegexContainsSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #o1
+            matches = Regex.Matches(str, Variables.VarKeyRegexContainsLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #o1
             if (0 < matches.Count)
                 refSet.Add(matches[0].Value);
 

--- a/PEBakery.Core/Commands/CommandBranch.cs
+++ b/PEBakery.Core/Commands/CommandBranch.cs
@@ -174,11 +174,11 @@ namespace PEBakery.Core.Commands
                 Script sc = Engine.GetScriptInstance(s, s.CurrentScript.RealPath, scriptFile, out bool inCurrentScript);
 
                 // Does section exist?
-                if (!sc.Sections.ContainsKey(sectionName))
+                if (!sc.Sections.TryGetValue(sectionName, out ScriptSection? targetSection))
                     throw new ExecuteException($"[{scriptFile}] does not have section [{sectionName}]");
 
                 // Section In Parameter
-                Dictionary<int, string> newInParams = new Dictionary<int, string>();
+                Dictionary<int, string> newInParams = [];
                 for (int i = 0; i < inParams.Count; i++)
                     newInParams[i + 1] = inParams[i];
 
@@ -243,16 +243,13 @@ namespace PEBakery.Core.Commands
                 else
                     logMessage = $"Loop [{sc.Title}]'s Section [{sectionName}] [{loopCount}] times";
                 s.Logger.BuildWrite(s, new LogInfo(LogState.Info, logMessage, cmd, ls.Depth));
-
-                // Loop it
-                ScriptSection targetSection = sc.Sections[sectionName];
                 int loopIdx = 1;
                 switch (type)
                 {
                     case CodeType.Loop:
                     case CodeType.LoopEx:
                         for (long i = startIdx; i <= endIdx; i++)
-                        { // Counter Variable is [#c]
+                        { // Counter Variable is [%^LOOP_IDX^] (legacy: [#c])
                             s.Logger.BuildWrite(s, new LogInfo(LogState.Info, $"Entering Loop with [{i}] ({loopIdx}/{loopCount})", cmd, ls.Depth));
                             s.Logger.LogSectionParameter(s, ls.Depth, newInParams, info.OutParams, cmd);
 

--- a/PEBakery.Core/Commands/CommandControl.cs
+++ b/PEBakery.Core/Commands/CommandControl.cs
@@ -67,7 +67,7 @@ namespace PEBakery.Core.Commands
                 case true:
                     {
                         // Check if interface contains VarKey
-                        List<LogInfo> logs = new List<LogInfo>();
+                        List<LogInfo> logs = [];
 
                         if (Variables.DetectType(info.VarKey) != Variables.VarKeyType.Variable)
                             goto case false;

--- a/PEBakery.Core/Commands/CommandNetwork.cs
+++ b/PEBakery.Core/Commands/CommandNetwork.cs
@@ -147,14 +147,11 @@ namespace PEBakery.Core.Commands
                     }
 
                     // PEBakery extension -> Report exit code via #r
-                    if (!s.CompatDisableLegacyExtendedSectionParams)
-                    {
-                        s.ReturnValue = statusCode.ToString();
-                        if (statusCode < 100)
-                            logs.Add(new LogInfo(LogState.Success, $"Returned [{statusCode}] into [#r]"));
-                        else
-                            logs.Add(new LogInfo(LogState.Success, $"Returned HTTP status code [{statusCode}] into [#r]"));
-                    }
+                    s.ReturnValue = statusCode.ToString();
+                    if (statusCode < 100)
+                        logs.Add(new LogInfo(LogState.Success, $"Returned [{statusCode}] into [%^RET%]"));
+                    else
+                        logs.Add(new LogInfo(LogState.Success, $"Returned HTTP status code [{statusCode}] into [%^RET%]"));
                 }
                 else
                 { // Validate downloaded file with hash
@@ -221,14 +218,11 @@ namespace PEBakery.Core.Commands
                     }
 
                     // PEBakery extension -> Report exit code via #r
-                    if (!s.CompatDisableLegacyExtendedSectionParams)
-                    {
-                        s.ReturnValue = statusCode.ToString();
-                        if (statusCode < 100)
-                            logs.Add(new LogInfo(LogState.Success, $"Returned [{statusCode}] into [#r]"));
-                        else
-                            logs.Add(new LogInfo(LogState.Success, $"Returned HTTP status code [{statusCode}] into [#r]"));
-                    }
+                    s.ReturnValue = statusCode.ToString();
+                    if (statusCode < 100)
+                        logs.Add(new LogInfo(LogState.Success, $"Returned [{statusCode}] into [%^RET%]"));
+                    else
+                        logs.Add(new LogInfo(LogState.Success, $"Returned HTTP status code [{statusCode}] into [%^RET%]"));
                 }
             }
             finally

--- a/PEBakery.Core/Commands/CommandNetwork.cs
+++ b/PEBakery.Core/Commands/CommandNetwork.cs
@@ -147,7 +147,7 @@ namespace PEBakery.Core.Commands
                     }
 
                     // PEBakery extension -> Report exit code via #r
-                    if (!s.CompatDisableExtendedSectionParams)
+                    if (!s.CompatDisableLegacyExtendedSectionParams)
                     {
                         s.ReturnValue = statusCode.ToString();
                         if (statusCode < 100)
@@ -221,7 +221,7 @@ namespace PEBakery.Core.Commands
                     }
 
                     // PEBakery extension -> Report exit code via #r
-                    if (!s.CompatDisableExtendedSectionParams)
+                    if (!s.CompatDisableLegacyExtendedSectionParams)
                     {
                         s.ReturnValue = statusCode.ToString();
                         if (statusCode < 100)

--- a/PEBakery.Core/Commands/CommandSystem.cs
+++ b/PEBakery.Core/Commands/CommandSystem.cs
@@ -706,7 +706,7 @@ namespace PEBakery.Core.Commands
                         }
 
                         // PEBakery extension -> Report exit code via #r
-                        if (!s.CompatDisableExtendedSectionParams)
+                        if (!s.CompatDisableLegacyExtendedSectionParams)
                         {
                             s.ReturnValue = exitCodeStr;
                             logs.Add(new LogInfo(LogState.Success, $"Returned exit code [{proc.ExitCode}] to [#r]"));

--- a/PEBakery.Core/Commands/CommandSystem.cs
+++ b/PEBakery.Core/Commands/CommandSystem.cs
@@ -706,11 +706,8 @@ namespace PEBakery.Core.Commands
                         }
 
                         // PEBakery extension -> Report exit code via #r
-                        if (!s.CompatDisableLegacyExtendedSectionParams)
-                        {
-                            s.ReturnValue = exitCodeStr;
-                            logs.Add(new LogInfo(LogState.Success, $"Returned exit code [{proc.ExitCode}] to [#r]"));
-                        }
+                        s.ReturnValue = exitCodeStr;
+                        logs.Add(new LogInfo(LogState.Success, $"Returned exit code [{proc.ExitCode}] to [%^RET%]"));
 
                         if (redirectStandardStream)
                         {

--- a/PEBakery.Core/CompatOption.cs
+++ b/PEBakery.Core/CompatOption.cs
@@ -40,24 +40,26 @@ namespace PEBakery.Core
         private readonly string _compatFile;
 
         // Script Tree
-        public bool AsteriskBugDirLink = false;
+        public bool AsteriskBugDirLink { get; set; } = false;
         // Command
-        public bool AsteriskBugDirCopy = false;
-        public bool FileRenameCanMoveDir = false;
-        public bool AllowLetterInLoop = false;
-        public bool LegacyBranchCondition = false;
-        public bool LegacyRegWrite = false;
-        public bool AllowSetModifyInterface = false;
-        public bool LegacyInterfaceCommand = false;
-        public bool LegacySectionParamCommand = false;
-        public bool AutoCompactIniWriteCommand = false;
+        public bool AsteriskBugDirCopy { get; set; } = false;
+        public bool FileRenameCanMoveDir { get; set; } = false;
+        public bool AllowLetterInLoop { get; set; } = false;
+        public bool LegacyBranchCondition { get; set; } = false;
+        public bool LegacyRegWrite { get; set; } = false;
+        public bool AllowSetModifyInterface { get; set; } = false;
+        public bool LegacyInterfaceCommand { get; set; } = false;
+        public bool LegacySectionParamCommand { get; set; } = false;
+        public bool AutoCompactIniWriteCommand { get; set; } = false;
         // Script Interface
-        public bool IgnoreWidthOfWebLabel = false;
+        public bool IgnoreWidthOfWebLabel { get; set; } = false;
         // Variable
-        public bool OverridableFixedVariables = false;
-        public bool OverridableLoopCounter = false;
-        public bool EnableEnvironmentVariables = false;
-        public bool DisableExtendedSectionParams = false;
+        public bool OverridableFixedVariables { get; set; } = false;
+        public bool OverridableLoopCounter { get; set; } = false;
+        public bool EnableEnvironmentVariables { get; set; } = false;
+        public bool EnableAllLegacySectionParams { get; set; } = false;
+        public bool DisableLegacyExtendedSectionParams { get; set; } = false;
+        private const string DisableLegacyExtendedSectionParamsOldName = "DisableExtendedSectionParams";
         #endregion
 
         #region Constructor
@@ -116,7 +118,8 @@ namespace PEBakery.Core
             OverridableFixedVariables = false;
             OverridableLoopCounter = false;
             EnableEnvironmentVariables = false;
-            DisableExtendedSectionParams = false;
+            EnableAllLegacySectionParams = true; // Breaking change, so do not set default to false 
+            DisableLegacyExtendedSectionParams = false;
         }
         #endregion
 
@@ -131,7 +134,7 @@ namespace PEBakery.Core
                 return;
 
             IniKey[] keys =
-            {
+            [
                 new IniKey(SectionName, nameof(AsteriskBugDirLink)), // Boolean
                 new IniKey(SectionName, nameof(AsteriskBugDirCopy)), // Boolean
                 new IniKey(SectionName, nameof(FileRenameCanMoveDir)), // Boolean
@@ -146,8 +149,9 @@ namespace PEBakery.Core
                 new IniKey(SectionName, nameof(OverridableFixedVariables)), // Boolean
                 new IniKey(SectionName, nameof(OverridableLoopCounter)), // Boolean
                 new IniKey(SectionName, nameof(EnableEnvironmentVariables)), // Boolean
-                new IniKey(SectionName, nameof(DisableExtendedSectionParams)), // Boolean
-            };
+                new IniKey(SectionName, nameof(EnableAllLegacySectionParams)), // Boolean
+                new IniKey(SectionName, nameof(DisableLegacyExtendedSectionParams)), // Boolean
+            ];
 
             keys = IniReadWriter.ReadKeys(_compatFile, keys);
             Dictionary<string, string?> keyDict = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
@@ -176,13 +180,15 @@ namespace PEBakery.Core
             OverridableFixedVariables = SettingDictParser.ParseBoolean(keyDict, SectionName, nameof(OverridableFixedVariables), OverridableFixedVariables);
             OverridableLoopCounter = SettingDictParser.ParseBoolean(keyDict, SectionName, nameof(OverridableLoopCounter), OverridableLoopCounter);
             EnableEnvironmentVariables = SettingDictParser.ParseBoolean(keyDict, SectionName, nameof(EnableEnvironmentVariables), EnableEnvironmentVariables);
-            DisableExtendedSectionParams = SettingDictParser.ParseBoolean(keyDict, SectionName, nameof(DisableExtendedSectionParams), DisableExtendedSectionParams);
+            EnableAllLegacySectionParams = SettingDictParser.ParseBoolean(keyDict, SectionName, nameof(EnableAllLegacySectionParams), EnableAllLegacySectionParams);
+            DisableLegacyExtendedSectionParams = SettingDictParser.ParseBoolean(keyDict, SectionName, nameof(DisableLegacyExtendedSectionParams), 
+                [DisableLegacyExtendedSectionParamsOldName], DisableLegacyExtendedSectionParams);
         }
 
         public void WriteToFile()
         {
             IniKey[] keys =
-            {
+            [
                 new IniKey(SectionName, nameof(AsteriskBugDirLink), AsteriskBugDirLink.ToString()), // Boolean
                 new IniKey(SectionName, nameof(AsteriskBugDirCopy), AsteriskBugDirCopy.ToString()), // Boolean
                 new IniKey(SectionName, nameof(FileRenameCanMoveDir), FileRenameCanMoveDir.ToString()), // Boolean
@@ -197,8 +203,9 @@ namespace PEBakery.Core
                 new IniKey(SectionName, nameof(OverridableFixedVariables), OverridableFixedVariables.ToString()), // Boolean
                 new IniKey(SectionName, nameof(OverridableLoopCounter), OverridableLoopCounter.ToString()), // Boolean
                 new IniKey(SectionName, nameof(EnableEnvironmentVariables), EnableEnvironmentVariables.ToString()), // Boolean
-                new IniKey(SectionName, nameof(DisableExtendedSectionParams), DisableExtendedSectionParams.ToString()), // Boolean
-            };
+                new IniKey(SectionName, nameof(EnableAllLegacySectionParams), EnableAllLegacySectionParams.ToString()), // Boolean
+                new IniKey(SectionName, nameof(DisableLegacyExtendedSectionParams), DisableLegacyExtendedSectionParams.ToString()), // Boolean
+            ];
             IniReadWriter.WriteKeys(_compatFile, keys);
         }
         #endregion
@@ -224,7 +231,8 @@ namespace PEBakery.Core
             dest.OverridableFixedVariables = OverridableFixedVariables;
             dest.OverridableLoopCounter = OverridableLoopCounter;
             dest.EnableEnvironmentVariables = EnableEnvironmentVariables;
-            dest.DisableExtendedSectionParams = DisableExtendedSectionParams;
+            dest.EnableAllLegacySectionParams = EnableAllLegacySectionParams;
+            dest.DisableLegacyExtendedSectionParams = DisableLegacyExtendedSectionParams;
         }
         #endregion
 
@@ -258,7 +266,8 @@ namespace PEBakery.Core
                 [nameof(OverridableFixedVariables)] = OverridableFixedVariables != other.OverridableFixedVariables,
                 [nameof(OverridableLoopCounter)] = OverridableLoopCounter != other.OverridableLoopCounter,
                 [nameof(EnableEnvironmentVariables)] = EnableEnvironmentVariables != other.EnableEnvironmentVariables,
-                [nameof(DisableExtendedSectionParams)] = DisableExtendedSectionParams != other.DisableExtendedSectionParams,
+                [nameof(EnableAllLegacySectionParams)] = EnableAllLegacySectionParams != other.EnableAllLegacySectionParams,
+                [nameof(DisableLegacyExtendedSectionParams)] = DisableLegacyExtendedSectionParams != other.DisableLegacyExtendedSectionParams,
             };
         }
         #endregion

--- a/PEBakery.Core/Engine.cs
+++ b/PEBakery.Core/Engine.cs
@@ -108,7 +108,7 @@ namespace PEBakery.Core
             s.Logger.BuildWrite(s, s.Macro.LoadMacroDict(MacroType.Local, sc, false));
 
             // Reset Current Section Parameters
-            s.CurSectionInParams = new Dictionary<int, string>();
+            s.CurSectionInParams = [];
             s.CurSectionOutParams = null;
 
             // Clear Processed Section Hashes
@@ -173,11 +173,10 @@ namespace PEBakery.Core
 
                     // Run Main Section
                     string entrySection = GetEntrySection(s);
-                    if (s.CurrentScript.Sections.ContainsKey(entrySection))
+                    if (s.CurrentScript.Sections.TryGetValue(entrySection, out ScriptSection? mainSection))
                     {
-                        ScriptSection mainSection = s.CurrentScript.Sections[entrySection];
                         s.Logger.LogStartOfSection(s, mainSection, 0, true, null, null);
-                        RunSection(s, mainSection, new List<string>(0), new List<string>(0), new EngineLocalState());
+                        RunSection(s, mainSection, new List<string>(0), [], new EngineLocalState());
                         s.Logger.LogEndOfSection(s, mainSection, 0, true, null);
                     }
 
@@ -336,10 +335,10 @@ namespace PEBakery.Core
         public static void RunSection(EngineState s, ScriptSection section, List<string> inParams, List<string>? outParams, EngineLocalState ls)
         {
             // Must copy inParams and outParams by value, not reference
-            Dictionary<int, string> inParamDict = new Dictionary<int, string>();
+            Dictionary<int, string> inParamDict = [];
             for (int i = 0; i < inParams.Count; i++)
                 inParamDict[i + 1] = StringEscaper.ExpandSectionParams(s, inParams[i]);
-            outParams = outParams == null ? new List<string>() : new List<string>(outParams);
+            outParams = outParams == null ? [] : [.. outParams];
 
             InternalRunSection(s, section, inParamDict, outParams, ls);
         }
@@ -348,7 +347,7 @@ namespace PEBakery.Core
         {
             // Must copy inParams and outParams by value, not reference
             Dictionary<int, string> inParamDict = new Dictionary<int, string>(inParams);
-            outParams = outParams == null ? new List<string>() : new List<string>(outParams);
+            outParams = outParams == null ? [] : [.. outParams];
 
             InternalRunSection(s, section, inParamDict, outParams, ls);
         }
@@ -423,7 +422,7 @@ namespace PEBakery.Core
                 s.PushLocalState(ls.IsMacro, ls.RefScriptId);
             }
 
-            List<LogInfo>? allLogs = s.TestMode ? new List<LogInfo>() : null;
+            List<LogInfo>? allLogs = s.TestMode ? [] : null;
             foreach (CodeCommand cmd in cmds)
             {
                 // Rollback the section parameters that could have be overwritten in ExecuteCommand().
@@ -476,7 +475,7 @@ namespace PEBakery.Core
         #region ExecuteCommand
         public static List<LogInfo> ExecuteCommand(EngineState s, CodeCommand cmd)
         {
-            List<LogInfo> logs = new List<LogInfo>();
+            List<LogInfo> logs = [];
             EngineLocalState ls = s.PeekLocalState();
 
             // Check CodeType / CodeInfo deprecation
@@ -1247,7 +1246,7 @@ namespace PEBakery.Core
         /// <summary>
         /// The 1-based index of in-params of current section.
         /// </summary>
-        public Dictionary<int, string> CurSectionInParams { get; set; } = new Dictionary<int, string>();
+        public Dictionary<int, string> CurSectionInParams { get; set; } = [];
         public List<string>? CurSectionOutParams { get; set; }
         public string ReturnValue { get; set; } = string.Empty;
         /// <summary>
@@ -1268,7 +1267,7 @@ namespace PEBakery.Core
         /// <summary>
         /// Track which lines were already processed
         /// </summary>
-        public HashSet<int> ProcessedLineSet { get; private set; } = new HashSet<int>();
+        public HashSet<int> ProcessedLineSet { get; private set; } = [];
         /// <summary>
         /// Accurate counter of how many section lines of the script was processed. 
         /// </summary>
@@ -1425,7 +1424,7 @@ namespace PEBakery.Core
                         if (runSingle.Equals(project.MainScript) && entrySection.Equals(ScriptSection.Names.Process, StringComparison.Ordinal))
                             goto case EngineMode.RunOne;
 
-                        Scripts = new List<Script>(2) { project.MainScript, runSingle };
+                        Scripts = [project.MainScript, runSingle];
                         TotalScripts = 1;
 
                         CurrentScript = Scripts[0];
@@ -1438,7 +1437,7 @@ namespace PEBakery.Core
                     { // Run only one script
                         if (runSingle == null)
                             throw new ArgumentNullException(nameof(runSingle));
-                        Scripts = new List<Script>(1) { runSingle };
+                        Scripts = [runSingle];
                         TotalScripts = 1;
 
                         CurrentScript = runSingle;

--- a/PEBakery.Core/Engine.cs
+++ b/PEBakery.Core/Engine.cs
@@ -1348,6 +1348,7 @@ namespace PEBakery.Core
         public bool CompatFileRenameCanMoveDir { get; set; } = false;
         public bool CompatAllowLetterInLoop { get; set; } = false;
         public bool CompatAllowSetModifyInterface { get; set; } = false;
+        public bool CompatEnableAllLegacySectionParams { get; set; } = false;
         public bool CompatDisableLegacyExtendedSectionParams { get; set; } = false;
         public bool CompatOverridableLoopCounter { get; set; } = false;
         public bool CompatAutoCompactIniWriteCommand { get; set; } = false;
@@ -1488,6 +1489,7 @@ namespace PEBakery.Core
             CompatFileRenameCanMoveDir = compat.FileRenameCanMoveDir;
             CompatAllowLetterInLoop = compat.AllowLetterInLoop;
             CompatAllowSetModifyInterface = compat.AllowSetModifyInterface;
+            CompatEnableAllLegacySectionParams = compat.EnableAllLegacySectionParams;
             CompatDisableLegacyExtendedSectionParams = compat.DisableLegacyExtendedSectionParams;
             CompatOverridableLoopCounter = compat.OverridableLoopCounter;
             CompatAutoCompactIniWriteCommand = compat.AutoCompactIniWriteCommand;

--- a/PEBakery.Core/Engine.cs
+++ b/PEBakery.Core/Engine.cs
@@ -1348,7 +1348,7 @@ namespace PEBakery.Core
         public bool CompatFileRenameCanMoveDir { get; set; } = false;
         public bool CompatAllowLetterInLoop { get; set; } = false;
         public bool CompatAllowSetModifyInterface { get; set; } = false;
-        public bool CompatDisableExtendedSectionParams { get; set; } = false;
+        public bool CompatDisableLegacyExtendedSectionParams { get; set; } = false;
         public bool CompatOverridableLoopCounter { get; set; } = false;
         public bool CompatAutoCompactIniWriteCommand { get; set; } = false;
         #endregion
@@ -1488,7 +1488,7 @@ namespace PEBakery.Core
             CompatFileRenameCanMoveDir = compat.FileRenameCanMoveDir;
             CompatAllowLetterInLoop = compat.AllowLetterInLoop;
             CompatAllowSetModifyInterface = compat.AllowSetModifyInterface;
-            CompatDisableExtendedSectionParams = compat.DisableExtendedSectionParams;
+            CompatDisableLegacyExtendedSectionParams = compat.DisableLegacyExtendedSectionParams;
             CompatOverridableLoopCounter = compat.OverridableLoopCounter;
             CompatAutoCompactIniWriteCommand = compat.AutoCompactIniWriteCommand;
         }

--- a/PEBakery.Core/Logger.cs
+++ b/PEBakery.Core/Logger.cs
@@ -931,7 +931,7 @@ namespace PEBakery.Core
             }
 
             // Write Section Out Parameters
-            if (outParams != null && 0 < outParams.Count && !s.CompatDisableExtendedSectionParams)
+            if (outParams != null && 0 < outParams.Count && !s.CompatDisableLegacyExtendedSectionParams)
             {
                 StringBuilder b = new StringBuilder();
                 b.Append("OutParams = { ");

--- a/PEBakery.Core/Logger.cs
+++ b/PEBakery.Core/Logger.cs
@@ -917,7 +917,7 @@ namespace PEBakery.Core
                 b.Append("InParams = { ");
                 foreach (var kv in inParams)
                 {
-                    b.Append($"#{kv.Key}:[{kv.Value}]");
+                    b.Append($"%^SPARAM_{kv.Key}:[{kv.Value}]");
                     if (cnt + 1 < inParams.Count)
                         b.Append(", ");
                     cnt++;
@@ -931,13 +931,13 @@ namespace PEBakery.Core
             }
 
             // Write Section Out Parameters
-            if (outParams != null && 0 < outParams.Count && !s.CompatDisableLegacyExtendedSectionParams)
+            if (outParams != null && 0 < outParams.Count)
             {
                 StringBuilder b = new StringBuilder();
                 b.Append("OutParams = { ");
                 for (int i = 0; i < outParams.Count; i++)
                 {
-                    b.Append($"#o{i}:[{outParams[i]}]");
+                    b.Append($"%^SOPARAM_{i}%:[{outParams[i]}]");
                     if (i + 1 < outParams.Count)
                         b.Append(", ");
                 }

--- a/PEBakery.Core/Script.cs
+++ b/PEBakery.Core/Script.cs
@@ -690,7 +690,7 @@ namespace PEBakery.Core
 
                                 _title = SilentDictParser.ParseString(mainIniDict, "Title", Path.GetFileName(RealPath));
                                 _description = SilentDictParser.ParseString(mainIniDict, "Description", string.Empty);
-                                _level = SilentDictParser.ParseInteger(mainIniDict, "Level", 0, null, null);
+                                _level = SilentDictParser.ParseIntegerWithinRange(mainIniDict, "Level", 0, null, null);
                             }
                             else
                             {

--- a/PEBakery.Core/Setting.cs
+++ b/PEBakery.Core/Setting.cs
@@ -462,8 +462,8 @@ namespace PEBakery.Core
 
             public static Color QueryThemeMainColor(ThemeType typeVal)
             {
-                if (MainColorDict.ContainsKey(typeVal))
-                    return MainColorDict[typeVal];
+                if (MainColorDict.TryGetValue(typeVal, out Color valColor))
+                    return valColor;
                 else
                     return Colors.Black;
             }
@@ -669,7 +669,7 @@ namespace PEBakery.Core
                 return;
 
             IniKey[] keys =
-            {
+            [
                 // Project
                 new IniKey(ProjectSetting.SectionName, nameof(Project.DefaultProject)), // String
                 // General
@@ -740,7 +740,7 @@ namespace PEBakery.Core
                 new IniKey(LogViewerSetting.SectionName, nameof(LogViewer.LogExportBuildIncludeComments)), // Boolean
                 new IniKey(LogViewerSetting.SectionName, nameof(LogViewer.LogExportBuildIncludeMacros)), // Boolean
                 new IniKey(LogViewerSetting.SectionName, nameof(LogViewer.LogExportBuildShowLogFlags)), // Boolean
-            };
+            ];
 
             keys = IniReadWriter.ReadKeys(_settingFile, keys);
 
@@ -758,18 +758,14 @@ namespace PEBakery.Core
             }
 
             // Project
-            if (keyDict.ContainsKey(ProjectSetting.SectionName))
+            if (keyDict.TryGetValue(ProjectSetting.SectionName, out Dictionary<string, string?>? projectDict) && projectDict is not null)
             {
-                Dictionary<string, string?> projectDict = keyDict[ProjectSetting.SectionName];
-
                 Project.DefaultProject = SettingDictParser.ParseString(projectDict, nameof(Project.DefaultProject), string.Empty);
             }
 
             // General
-            if (keyDict.ContainsKey(GeneralSetting.SectionName))
+            if (keyDict.TryGetValue(GeneralSetting.SectionName, out Dictionary<string, string?>? generalDict) && generalDict is not null)
             {
-                Dictionary<string, string?> generalDict = keyDict[GeneralSetting.SectionName];
-
                 General.OptimizeCode = SettingDictParser.ParseBoolean(generalDict, GeneralSetting.SectionName, nameof(General.OptimizeCode), General.OptimizeCode);
                 General.ShowLogAfterBuild = SettingDictParser.ParseBoolean(generalDict, GeneralSetting.SectionName, nameof(General.ShowLogAfterBuild), General.ShowLogAfterBuild);
                 General.StopBuildOnError = SettingDictParser.ParseBoolean(generalDict, GeneralSetting.SectionName, nameof(General.StopBuildOnError), General.StopBuildOnError);
@@ -781,10 +777,8 @@ namespace PEBakery.Core
             }
 
             // Interface
-            if (keyDict.ContainsKey(InterfaceSetting.SectionName))
+            if (keyDict.TryGetValue(InterfaceSetting.SectionName, out Dictionary<string, string?>? ifaceDict) && ifaceDict is not null)
             {
-                Dictionary<string, string?> ifaceDict = keyDict[InterfaceSetting.SectionName];
-
                 // Parse MonospacedFont
                 FontFamily monoFontFamily = Interface.MonospacedFont.FontFamily;
                 FontWeight monoFontWeight = Interface.MonospacedFont.FontWeight;
@@ -827,48 +821,40 @@ namespace PEBakery.Core
             }
 
             // Theme
-            if (keyDict.ContainsKey(ThemeSetting.SectionName))
+            if (keyDict.TryGetValue(ThemeSetting.SectionName, out Dictionary<string, string?>? themeDict) && themeDict is not null)
             {
-                Dictionary<string, string?> scDict = keyDict[ThemeSetting.SectionName];
-
-                Theme.ThemeType = SettingDictParser.ParseStrEnum(scDict, ThemeSetting.SectionName, nameof(Theme.ThemeType), Theme.ThemeType);
-                Theme.CustomTopPanelBackground = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomTopPanelBackground), Theme.CustomTopPanelBackground);
-                Theme.CustomTopPanelForeground = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomTopPanelForeground), Theme.CustomTopPanelForeground);
-                Theme.CustomTopPanelIssueAlarmButton = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomTopPanelIssueAlarmButton), Theme.CustomTopPanelIssueAlarmButton);
-                Theme.CustomTopPanelIssueAlarmBadge = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomTopPanelIssueAlarmBadge), Theme.CustomTopPanelIssueAlarmBadge);
-                Theme.CustomTreePanelBackground = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomTreePanelBackground), Theme.CustomTreePanelBackground);
-                Theme.CustomTreePanelForeground = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomTreePanelForeground), Theme.CustomTreePanelForeground);
-                Theme.CustomTreePanelHighlight = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomTreePanelHighlight), Theme.CustomTreePanelHighlight);
-                Theme.CustomScriptPanelBackground = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomScriptPanelBackground), Theme.CustomScriptPanelBackground);
-                Theme.CustomScriptPanelForeground = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomScriptPanelForeground), Theme.CustomScriptPanelForeground);
-                Theme.CustomStatusBarBackground = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomStatusBarBackground), Theme.CustomStatusBarBackground);
-                Theme.CustomStatusBarForeground = SettingDictParser.ParseColor(scDict, ThemeSetting.SectionName, nameof(Theme.CustomStatusBarForeground), Theme.CustomStatusBarForeground);
+                Theme.ThemeType = SettingDictParser.ParseStrEnum(themeDict, ThemeSetting.SectionName, nameof(Theme.ThemeType), Theme.ThemeType);
+                Theme.CustomTopPanelBackground = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomTopPanelBackground), Theme.CustomTopPanelBackground);
+                Theme.CustomTopPanelForeground = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomTopPanelForeground), Theme.CustomTopPanelForeground);
+                Theme.CustomTopPanelIssueAlarmButton = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomTopPanelIssueAlarmButton), Theme.CustomTopPanelIssueAlarmButton);
+                Theme.CustomTopPanelIssueAlarmBadge = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomTopPanelIssueAlarmBadge), Theme.CustomTopPanelIssueAlarmBadge);
+                Theme.CustomTreePanelBackground = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomTreePanelBackground), Theme.CustomTreePanelBackground);
+                Theme.CustomTreePanelForeground = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomTreePanelForeground), Theme.CustomTreePanelForeground);
+                Theme.CustomTreePanelHighlight = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomTreePanelHighlight), Theme.CustomTreePanelHighlight);
+                Theme.CustomScriptPanelBackground = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomScriptPanelBackground), Theme.CustomScriptPanelBackground);
+                Theme.CustomScriptPanelForeground = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomScriptPanelForeground), Theme.CustomScriptPanelForeground);
+                Theme.CustomStatusBarBackground = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomStatusBarBackground), Theme.CustomStatusBarBackground);
+                Theme.CustomStatusBarForeground = SettingDictParser.ParseColor(themeDict, ThemeSetting.SectionName, nameof(Theme.CustomStatusBarForeground), Theme.CustomStatusBarForeground);
             }
 
             // Script
-            if (keyDict.ContainsKey(ScriptSetting.SectionName))
+            if (keyDict.TryGetValue(ScriptSetting.SectionName, out Dictionary<string, string?>? scDict) && scDict is not null)
             {
-                Dictionary<string, string?> scDict = keyDict[ScriptSetting.SectionName];
-
                 Script.EnableCache = SettingDictParser.ParseBoolean(scDict, ScriptSetting.SectionName, nameof(Script.EnableCache), Script.EnableCache);
                 Script.AutoSyntaxCheck = SettingDictParser.ParseBoolean(scDict, ScriptSetting.SectionName, nameof(Script.AutoSyntaxCheck), Script.AutoSyntaxCheck);
             }
 
             // Log
-            if (keyDict.ContainsKey(LogSetting.SectionName))
+            if (keyDict.TryGetValue(LogSetting.SectionName, out Dictionary<string, string?>? logDict) && logDict is not null)
             {
-                Dictionary<string, string?> logDict = keyDict[LogSetting.SectionName];
-
                 Log.DebugLevel = SettingDictParser.ParseIntEnum(logDict, LogSetting.SectionName, nameof(Log.DebugLevel), Log.DebugLevel);
                 Log.DeferredLogging = SettingDictParser.ParseBoolean(logDict, LogSetting.SectionName, nameof(Log.DeferredLogging), Log.DeferredLogging);
                 Log.MinifyHtmlExport = SettingDictParser.ParseBoolean(logDict, LogSetting.SectionName, nameof(Log.MinifyHtmlExport), Log.MinifyHtmlExport);
             }
 
             // LogViewer
-            if (keyDict.ContainsKey(LogViewerSetting.SectionName))
+            if (keyDict.TryGetValue(LogViewerSetting.SectionName, out Dictionary<string, string?>? logViewDict) && logViewDict is not null)
             {
-                Dictionary<string, string?> logViewDict = keyDict[LogViewerSetting.SectionName];
-
                 LogViewer.LogWindowWidth = SettingDictParser.ParseInteger(logViewDict, LogViewerSetting.SectionName, nameof(LogViewer.LogWindowWidth), LogViewer.LogWindowWidth, 600, null);
                 LogViewer.LogWindowHeight = SettingDictParser.ParseInteger(logViewDict, LogViewerSetting.SectionName, nameof(LogViewer.LogWindowHeight), LogViewer.LogWindowHeight, 480, null);
                 LogViewer.BuildFullLogTimeVisible = SettingDictParser.ParseBoolean(logViewDict, LogViewerSetting.SectionName, nameof(LogViewer.BuildFullLogTimeVisible), LogViewer.BuildFullLogTimeVisible);
@@ -899,7 +885,7 @@ namespace PEBakery.Core
             static string WriteColor(Color c) => $"{c.R}, {c.G}, {c.B}";
 
             IniKey[] keys =
-            {
+            [
                 // Project
                 new IniKey(ProjectSetting.SectionName, nameof(Project.DefaultProject), Project.DefaultProject), // String
                 // General
@@ -970,7 +956,7 @@ namespace PEBakery.Core
                 new IniKey(LogViewerSetting.SectionName, nameof(LogViewer.LogExportBuildIncludeComments), LogViewer.LogExportBuildIncludeComments.ToString()), // Boolean
                 new IniKey(LogViewerSetting.SectionName, nameof(LogViewer.LogExportBuildIncludeMacros), LogViewer.LogExportBuildIncludeMacros.ToString()), // Boolean
                 new IniKey(LogViewerSetting.SectionName, nameof(LogViewer.LogExportBuildShowLogFlags), LogViewer.LogExportBuildShowLogFlags.ToString()), // Boolean
-            };
+            ];
             IniReadWriter.WriteKeys(_settingFile, keys);
         }
         #endregion
@@ -985,20 +971,49 @@ namespace PEBakery.Core
             return SilentDictParser.ParseStringNullable(dict, key, defaultValue);
         }
 
+        public static string ParseString(Dictionary<string, string?> dict, string primaryKey, IReadOnlyList<string> fallbackKeys, string defaultValue)
+        {
+            return SilentDictParser.ParseStringNullable(dict, primaryKey, fallbackKeys, defaultValue);
+        }
+
         public static bool ParseBoolean(Dictionary<string, string?> dict, string section, string key, bool defaultValue)
         {
+            
             bool val = SilentDictParser.ParseBooleanNullable(dict, key, defaultValue, out bool incorrectValue);
             if (incorrectValue)
-                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{key}] has incorrect value: {dict[key]}"));
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{key}] has incorrect value: {(dict.TryGetValue(key, out string? valStr) ? valStr : string.Empty)}"));
+            return val;
+        }
+
+        public static bool ParseBoolean(Dictionary<string, string?> dict, string section, string primaryKey, IReadOnlyList<string> fallbackKeys, bool defaultValue)
+        {
+            bool val = SilentDictParser.ParseBooleanNullable(dict, primaryKey, fallbackKeys, defaultValue, out bool incorrectValue);
+            if (incorrectValue)
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{primaryKey}] has incorrect value: {(dict.TryGetValue(primaryKey, out string? valStr) ? valStr : string.Empty)}"));
             return val;
         }
 
         public static int ParseInteger(Dictionary<string, string?> dict, string section, string key, int defaultValue, int? min, int? max)
         {
-            int val = SilentDictParser.ParseIntegerNullable(dict, key, defaultValue, min, max, out bool incorrectValue);
+            int val = SilentDictParser.ParseIntegerWithinRangeNullable(dict, key, defaultValue, min, max, out bool incorrectValue);
             if (incorrectValue)
             {
-                string msg = $"Setting [{section}.{key}] has incorrect value: {dict[key]}";
+                string msg = $"Setting [{section}.{key}] has incorrect value: {(dict.TryGetValue(key, out string? valStr) ? valStr : string.Empty)}";
+                if (min is int minVal && val == minVal)
+                    msg += $" (Requires [{minVal} <= val])";
+                if (max is int maxVal && val == maxVal)
+                    msg += $" (Requires [val <= {maxVal}])";
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, msg));
+            }
+            return val;
+        }
+
+        public static int ParseInteger(Dictionary<string, string?> dict, string section, string primaryKey, IReadOnlyList<string> fallbackKeys, int defaultValue, int? min, int? max)
+        {
+            int val = SilentDictParser.ParseIntegerWithinRangeNullable(dict, primaryKey, fallbackKeys, defaultValue, min, max, out bool incorrectValue);
+            if (incorrectValue)
+            {
+                string msg = $"Setting [{section}.{primaryKey}] has incorrect value: {(dict.TryGetValue(primaryKey, out string? valStr) ? valStr : string.Empty)}";
                 if (min is int minVal && val == minVal)
                     msg += $" (Requires [{minVal} <= val])";
                 if (max is int maxVal && val == maxVal)
@@ -1013,7 +1028,16 @@ namespace PEBakery.Core
         {
             TEnum val = SilentDictParser.ParseStrEnumNullable(dict, key, defaultValue, out bool incorrectValue);
             if (incorrectValue)
-                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{key}] has incorrect value: {dict[key]}"));
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{key}] has incorrect value: {(dict.TryGetValue(key, out string? valStr) ? valStr : string.Empty)}"));
+            return val;
+        }
+
+        public static TEnum ParseStrEnum<TEnum>(Dictionary<string, string?> dict, string section, string primaryKey, IReadOnlyList<string> fallbackKeys, TEnum defaultValue)
+            where TEnum : struct, Enum
+        {
+            TEnum val = SilentDictParser.ParseStrEnumNullable(dict, primaryKey, fallbackKeys, defaultValue, out bool incorrectValue);
+            if (incorrectValue)
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{primaryKey}] has incorrect value: {(dict.TryGetValue(primaryKey, out string? valStr) ? valStr : string.Empty)}"));
             return val;
         }
 
@@ -1022,7 +1046,16 @@ namespace PEBakery.Core
         {
             TEnum val = SilentDictParser.ParseIntEnumNullable(dict, key, defaultValue, out bool incorrectValue);
             if (incorrectValue)
-                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{key}] has incorrect value: {dict[key]}"));
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{key}] has incorrect value: {(dict.TryGetValue(key, out string? valStr) ? valStr : string.Empty)}"));
+            return val;
+        }
+
+        public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string?> dict, string section, string primaryKey, IReadOnlyList<string> fallbackKeys, TEnum defaultValue)
+            where TEnum : Enum
+        {
+            TEnum val = SilentDictParser.ParseIntEnumNullable(dict, primaryKey, defaultValue, out bool incorrectValue);
+            if (incorrectValue)
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{primaryKey}] has incorrect value: {(dict.TryGetValue(primaryKey, out string? valStr) ? valStr : string.Empty)}"));
             return val;
         }
 
@@ -1030,7 +1063,15 @@ namespace PEBakery.Core
         {
             Color val = SilentDictParser.ParseColorNullable(dict, key, defaultValue, out bool incorrectValue);
             if (incorrectValue)
-                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{key}] has incorrect value: {dict[key]}"));
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{key}] has incorrect value: {(dict.TryGetValue(key, out string? valStr) ? valStr : string.Empty)}"));
+            return val;
+        }
+
+        public static Color ParseColor(Dictionary<string, string?> dict, string section, string primaryKey, IReadOnlyList<string> fallbackKeys, Color defaultValue)
+        {
+            Color val = SilentDictParser.ParseColorNullable(dict, primaryKey, fallbackKeys, defaultValue, out bool incorrectValue);
+            if (incorrectValue)
+                Global.Logger.SystemWrite(new LogInfo(LogState.Error, $"Setting [{section}.{primaryKey}] has incorrect value: {(dict.TryGetValue(primaryKey, out string? valStr) ? valStr : string.Empty)}"));
             return val;
         }
     }

--- a/PEBakery.Core/StringEscaper.cs
+++ b/PEBakery.Core/StringEscaper.cs
@@ -528,7 +528,7 @@ namespace PEBakery.Core
                 matches = inRegex.Matches(str);
             }
 
-            if (!s.CompatDisableExtendedSectionParams)
+            if (!s.CompatDisableLegacyExtendedSectionParams)
             {
                 // Expand #o1, #o2, ... (Section Out Parameter)
                 if (s.CurSectionOutParams != null)
@@ -714,7 +714,7 @@ namespace PEBakery.Core
                     }
                     else if (pKind.Equals("SOPARAM", StringComparison.OrdinalIgnoreCase))
                     { // Expand Section Out Parameter
-                        if (!s.CompatDisableExtendedSectionParams && s.CurSectionOutParams != null)
+                        if (!s.CompatDisableLegacyExtendedSectionParams && s.CurSectionOutParams != null)
                         {
                             string param;
                             if (s.CurSectionInParams.TryGetValue(pIdx, out string? value))

--- a/PEBakery.Core/StringEscaper.cs
+++ b/PEBakery.Core/StringEscaper.cs
@@ -103,7 +103,7 @@ namespace PEBakery.Core
             // Windows Reserved Characters
             // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
             // Exclude backslash, because this function will receive 
-            char[] invalidChars = Path.GetInvalidFileNameChars().Where(x => x != '\\').ToArray();
+            char[] invalidChars = [.. Path.GetInvalidFileNameChars().Where(x => x != '\\')];
 
             // Ex) "C:\Program Files"
             Match m = Regex.Match(path, "^[A-Za-z]:", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -318,7 +318,7 @@ namespace PEBakery.Core
 
         public static List<string> Unescape(IEnumerable<string> strs, bool escapePercent = false)
         {
-            return strs.Select(str => Unescape(str, escapePercent)).ToList();
+            return [.. strs.Select(str => Unescape(str, escapePercent))];
         }
 
         public static string QuoteUnescape(string str, bool escapePercent = false)
@@ -366,7 +366,7 @@ namespace PEBakery.Core
         public static string Escape(string str, bool fullEscape = false, bool escapePercent = false)
         {
             // Escape # first
-            if (str.IndexOf('#') != -1)
+            if (str.Contains('#'))
             {
                 int idx = 0;
                 StringBuilder b = new StringBuilder();
@@ -399,7 +399,7 @@ namespace PEBakery.Core
 
         public static List<string> Escape(IEnumerable<string> strs, bool fullEscape = false, bool escapePercent = false)
         {
-            return strs.Select(str => Escape(str, fullEscape, escapePercent)).ToList();
+            return [.. strs.Select(str => Escape(str, fullEscape, escapePercent))];
         }
 
         public static string EscapePercent(string str)
@@ -409,7 +409,7 @@ namespace PEBakery.Core
 
         public static List<string> EscapePercent(IEnumerable<string> strs)
         {
-            return strs.Select(EscapePercent).ToList();
+            return [.. strs.Select(EscapePercent)];
         }
 
         public static string DoubleQuote(string str)
@@ -433,7 +433,7 @@ namespace PEBakery.Core
 
         public static List<string> QuoteEscape(IEnumerable<string> strs, bool fullEscape = false, bool escapePercent = false)
         {
-            return strs.Select(str => QuoteEscape(str, fullEscape, escapePercent)).ToList();
+            return [.. strs.Select(str => QuoteEscape(str, fullEscape, escapePercent))];
         }
         #endregion
 
@@ -451,7 +451,7 @@ namespace PEBakery.Core
 
         public static List<string> ExpandVariables(EngineState s, IEnumerable<string> strs)
         {
-            return strs.Select(str => s.Variables.Expand(ExpandSectionParams(s, str))).ToList();
+            return [.. strs.Select(str => s.Variables.Expand(ExpandSectionParams(s, str)))];
         }
 
         public static string ExpandVariables(Variables vars, string str)
@@ -461,13 +461,25 @@ namespace PEBakery.Core
 
         public static List<string> ExpandVariables(Variables vars, IEnumerable<string> strs)
         {
-            return strs.Select(vars.Expand).ToList();
+            return [.. strs.Select(vars.Expand)];
+        }
+
+        public static string ExpandSectionParams(EngineState s, string str)
+        {
+            // TODO: Wire ExpandPercentPatternSectionParams
+            return ExpandLegacySharpSectionParams(s, str);
+        }
+
+        public static List<string> ExpandSectionParams(EngineState s, IEnumerable<string> strs)
+        {
+            // TODO: Wire ExpandPercentPatternSectionParams
+            return ExpandLegacySharpSectionParams(s, strs);
         }
 
         /// <summary>
-        /// Expand #1, #2, #3, etc...
+        /// Expand old legacy-sharp section parameters, such as #1, #2, #3, etc...
         /// </summary>
-        public static string ExpandSectionParams(EngineState s, string str)
+        public static string ExpandLegacySharpSectionParams(EngineState s, string str)
         {
             // Expand #1 into its value
             Regex inRegex = new Regex(@"(?<!#)(#[1-9])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -493,9 +505,9 @@ namespace PEBakery.Core
                     }
 
                     string param;
-                    if (s.CurSectionInParams.ContainsKey(pIdx))
+                    if (s.CurSectionInParams.TryGetValue(pIdx, out string? value))
                     {
-                        param = s.CurSectionInParams[pIdx];
+                        param = value;
                     }
                     else
                     {
@@ -518,7 +530,7 @@ namespace PEBakery.Core
 
             if (!s.CompatDisableExtendedSectionParams)
             {
-                // Escape #o1, #o2, ... (Section Out Parameter)
+                // Expand #o1, #o2, ... (Section Out Parameter)
                 if (s.CurSectionOutParams != null)
                 {
                     Regex outRegex = new Regex(@"(?<!#)(#[oO][1-9])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -566,20 +578,20 @@ namespace PEBakery.Core
                     }
                 }
 
-                // Escape #a (Section In Params Count)
-                if (str.IndexOf("#a", StringComparison.OrdinalIgnoreCase) != -1)
+                // Expand #a (Section In Params Count)
+                if (str.Contains("#a", StringComparison.OrdinalIgnoreCase))
                     str = StringHelper.ReplaceRegex(str, @"(?<!#)(#[aA])", s.CurSectionInParamsCount.ToString());
 
-                // Escape #oa (Section Out Params Count)
-                if (str.IndexOf("#oa", StringComparison.OrdinalIgnoreCase) != -1)
+                // Expand #oa (Section Out Params Count)
+                if (str.Contains("#oa", StringComparison.OrdinalIgnoreCase))
                     str = StringHelper.ReplaceRegex(str, @"(?<!#)(#[oO][aA])", s.CurSectionInParamsCount.ToString());
 
-                // Escape #r (Return Value)
-                if (str.IndexOf("#r", StringComparison.OrdinalIgnoreCase) != -1)
+                // Expand #r (Return Value)
+                if (str.Contains("#r", StringComparison.OrdinalIgnoreCase))
                     str = StringHelper.ReplaceRegex(str, @"(?<!#)(#[rR])", s.ReturnValue);
             }
 
-            // Escape #c (Loop Counter)
+            // Expand #c (Loop Counter)
             if (0 < s.LoopCmdStateStack.Count)
             {
                 EngineLoopCmdState loop = s.LoopCmdStateStack.Peek();
@@ -597,13 +609,151 @@ namespace PEBakery.Core
             return str;
         }
 
-        public static List<string> ExpandSectionParams(EngineState s, IEnumerable<string> strs)
+        /// <summary>
+        /// Expand old legacy-sharp section parameters, such as #1, #2, #3, etc...
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="strs"></param>
+        /// <returns></returns>
+        public static List<string> ExpandLegacySharpSectionParams(EngineState s, IEnumerable<string> strs)
         {
-            return strs.Select(str => ExpandSectionParams(s, str)).ToList();
+            return [.. strs.Select(str => ExpandLegacySharpSectionParams(s, str))];
+        }
+
+        /// <summary>
+        /// Expand new percent-style section parameters.
+        /// </summary>
+        /// <remarks>
+        /// %^RET%: #r
+        /// %^SPARAM_<NUMBERS>%, %^SIPARAM_<NUMBERS>%: #1 ~ #9
+        /// %^SPARAM_COUNT%, %^SIPARAM_COUNT%: #a
+        /// %^SOPARAM_<NUMBERS>%: #o1 ~ #o9
+        /// %^SOPARAM_COUNT%: #oa
+        /// %^LOOP_IDX%: #c
+        /// </remarks>
+        public static string ExpandPercentPatternSectionParams(EngineState s, string str)
+        {
+            // Expand #1 into its value
+            Regex paramRegex = new Regex(@"%\^([A-Za-z0-9_]+)%", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Regex pSectVarRegex = new Regex(@"^(S(?:I?|O)PARAM)_([0-9]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            StringBuilder b = new StringBuilder();
+
+            int lastCopiedIdx = 0;
+            MatchCollection matches = paramRegex.Matches(str);
+            if (matches.Count == 0)
+                return str;
+
+            for (int x = 0; x < matches.Count; x++)
+            {
+                string paramNameStr = matches[x].Groups[1].ToString();
+                lastCopiedIdx = matches[x].Index + matches[x].Length;
+
+                if (x == 0)
+                {
+                    b.Append(str[..matches[0].Index]);
+                }
+                else
+                {
+                    int startOffset = matches[x - 1].Index + matches[x - 1].Length;
+                    int endOffset = matches[x].Index - startOffset;
+                    b.Append(str.AsSpan(startOffset, endOffset));
+                }
+
+                if (paramNameStr.Equals("RET", StringComparison.OrdinalIgnoreCase))
+                { // Expand Return Value
+                    b.Append(s.ReturnValue);
+                    continue;
+                }
+                else if (paramNameStr.Equals("SPARAM_COUNT", StringComparison.OrdinalIgnoreCase) ||
+                        paramNameStr.Equals("SIPARAM_COUNT", StringComparison.OrdinalIgnoreCase))
+                { // Expand Section In Params Count
+                    b.Append(s.CurSectionInParamsCount);
+                    continue;
+                }
+                else if (paramNameStr.Equals("SOPARAM_COUNT", StringComparison.OrdinalIgnoreCase))
+                { // Expand Section Out Params Count
+                    b.Append(s.CurSectionOutParamsCount);
+                    continue;
+                }
+                else if (paramNameStr.Equals("LOOP_IDX", StringComparison.OrdinalIgnoreCase))
+                { // Expand Loop Counter
+                    if (0 < s.LoopCmdStateStack.Count)
+                    {
+                        EngineLoopCmdState loop = s.LoopCmdStateStack.Peek();
+                        switch (loop.State)
+                        {
+                            case LoopCmdState.OnIndex:
+                                b.Append(loop.CounterIndex);
+                                break;
+                            case LoopCmdState.OnDriveLetter:
+                                b.Append(loop.CounterLetter);
+                                break;
+                        }
+                        continue;
+                    }
+                }
+                else
+                {
+                    Match pSectMatch = pSectVarRegex.Match(paramNameStr);
+                    string pKind = pSectMatch.Groups[1].Value;
+                    string pIdxStr = pSectMatch.Groups[2].Value;
+
+                    if (!int.TryParse(pIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out int pIdx))
+                        throw new InternalException($"{nameof(ExpandPercentPatternSectionParams)} failure");
+
+                    if (pKind.Equals("SPARAM", StringComparison.OrdinalIgnoreCase) ||
+                        pKind.Equals("SIPARAM", StringComparison.OrdinalIgnoreCase))
+                    { // Expand Section In Parameter
+                        string param;
+                        if (s.CurSectionInParams.TryGetValue(pIdx, out string? value))
+                            param = value;
+                        else
+                            param = string.Empty; // Not in entry section -> return string.Empty;
+                        
+                        b.Append(param);
+                    }
+                    else if (pKind.Equals("SOPARAM", StringComparison.OrdinalIgnoreCase))
+                    { // Expand Section Out Parameter
+                        if (!s.CompatDisableExtendedSectionParams && s.CurSectionOutParams != null)
+                        {
+                            string param;
+                            if (s.CurSectionInParams.TryGetValue(pIdx, out string? value))
+                                param = value;
+                            else
+                                param = string.Empty; // Not in entry section -> return string.Empty;
+
+                            b.Append(param);
+                        }
+                    }
+                }
+            }
+
+            b.Append(str.AsSpan(lastCopiedIdx..));
+            str = b.ToString();
+
+            return str;
+        }
+
+        /// <summary>
+        /// Expand new percent-style section parameters, such as #1, #2, #3, etc...
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="strs"></param>
+        /// <returns></returns>
+        public static List<string> ExpandPercentPatternSectionParams(EngineState s, IEnumerable<string> strs)
+        {
+            return [.. strs.Select(str => ExpandPercentPatternSectionParams(s, str))];
         }
         #endregion
 
         #region Preprocess
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="str"></param>
+        /// <param name="escapePercent"></param>
+        /// <returns></returns>
         public static string Preprocess(EngineState s, string str, bool escapePercent = true)
         {
             return Unescape(ExpandVariables(s, str), escapePercent);
@@ -631,7 +781,7 @@ namespace PEBakery.Core
             int idx = startIdx;
             string key;
             bool duplicate;
-            string[] keyArr = keys.ToArray();
+            string[] keyArr = [.. keys];
             do
             {
                 duplicate = false;
@@ -655,7 +805,7 @@ namespace PEBakery.Core
             int idx = 0;
             string key;
             bool duplicate;
-            string[] keyArr = keys.ToArray();
+            string[] keyArr = [.. keys];
             do
             {
                 idx++;
@@ -737,7 +887,7 @@ namespace PEBakery.Core
         {
             StringBuilder b = new StringBuilder();
 
-            string[] list = multiStrs.ToArray();
+            string[] list = [.. multiStrs];
             for (int i = 0; i < list.Length; i++)
             {
                 byte[] bin = Encoding.Unicode.GetBytes(list[i]);
@@ -754,7 +904,7 @@ namespace PEBakery.Core
             // RegRead,HKLM,SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink,Batang,%A%
             // MSMINCHO.TTC,MS PMincho#$zMINGLIU.TTC,PMingLiU#$zSIMSUN.TTC,SimSun#$zMALGUN.TTF,Malgun Gothic#$zYUGOTHM.TTC,Yu Gothic UI#$zMSJH.TTC,Microsoft JhengHei UI#$zMSYH.TTC,Microsoft YaHei UI#$zSEGUISYM.TTF,Segoe UI Symbol
 
-            string[] list = multiStrs.ToArray();
+            string[] list = [.. multiStrs];
 
             StringBuilder b = new StringBuilder();
             for (int i = 0; i < list.Length; i++)
@@ -771,7 +921,7 @@ namespace PEBakery.Core
             // RegRead,HKLM,SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink,Batang,%A%
             // MSMINCHO.TTC,MS PMincho#$zMINGLIU.TTC,PMingLiU#$zSIMSUN.TTC,SimSun#$zMALGUN.TTF,Malgun Gothic#$zYUGOTHM.TTC,Yu Gothic UI#$zMSJH.TTC,Microsoft JhengHei UI#$zMSYH.TTC,Microsoft YaHei UI#$zSEGUISYM.TTF,Segoe UI Symbol
 
-            List<string> list = new List<string>();
+            List<string> list = [];
 
             string? next = packStr;
             while (next != null)

--- a/PEBakery.Core/StringEscaper.cs
+++ b/PEBakery.Core/StringEscaper.cs
@@ -719,11 +719,15 @@ namespace PEBakery.Core
                         if (s.CurSectionOutParams != null)
                         {
                             string param;
-                            if (s.CurSectionInParams.TryGetValue(pIdx, out string? value))
-                                param = value;
+                            if (1 <= pIdx && pIdx <= s.CurSectionOutParams.Count)
+                            {
+                                string varKey = s.CurSectionOutParams[pIdx - 1];
+                                param = s.Variables.Expand(varKey);
+                            }
                             else
-                                param = string.Empty; // Not in entry section -> return string.Empty;
-
+                            {
+                                param = string.Empty;
+                            }
                             b.Append(param);
                         }
                     }

--- a/PEBakery.Core/StringEscaper.cs
+++ b/PEBakery.Core/StringEscaper.cs
@@ -35,8 +35,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 
-#nullable enable
-
 namespace PEBakery.Core
 {
     public static class StringEscaper
@@ -466,14 +464,20 @@ namespace PEBakery.Core
 
         public static string ExpandSectionParams(EngineState s, string str)
         {
-            // TODO: Wire ExpandPercentPatternSectionParams
-            return ExpandLegacySharpSectionParams(s, str);
+            string expandedStr = str;
+            if (s.CompatEnableAllLegacySectionParams)
+                expandedStr = ExpandLegacySharpSectionParams(s, expandedStr);
+            expandedStr = ExpandPercentPatternSectionParams(s, expandedStr);
+            return expandedStr;
         }
 
         public static List<string> ExpandSectionParams(EngineState s, IEnumerable<string> strs)
         {
-            // TODO: Wire ExpandPercentPatternSectionParams
-            return ExpandLegacySharpSectionParams(s, strs);
+            List<string> expandedStrs = [.. strs];
+            if (s.CompatEnableAllLegacySectionParams)
+                expandedStrs = ExpandLegacySharpSectionParams(s, strs);
+            expandedStrs = ExpandPercentPatternSectionParams(s, expandedStrs);
+            return expandedStrs;
         }
 
         /// <summary>
@@ -625,8 +629,8 @@ namespace PEBakery.Core
         /// </summary>
         /// <remarks>
         /// %^RET%: #r
-        /// %^SPARAM_<NUMBERS>%, %^SIPARAM_<NUMBERS>%: #1 ~ #9
-        /// %^SPARAM_COUNT%, %^SIPARAM_COUNT%: #a
+        /// %^SIPARAM_<NUMBERS>%, %^SIPARAM_<NUMBERS>%: #1 ~ #9
+        /// %^SIPARAM_COUNT%, %^SIPARAM_COUNT%: #a
         /// %^SOPARAM_<NUMBERS>%: #o1 ~ #o9
         /// %^SOPARAM_COUNT%: #oa
         /// %^LOOP_IDX%: #c
@@ -635,7 +639,7 @@ namespace PEBakery.Core
         {
             // Expand #1 into its value
             Regex paramRegex = new Regex(@"%\^([A-Za-z0-9_]+)%", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-            Regex pSectVarRegex = new Regex(@"^(S(?:I?|O)PARAM)_([0-9]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            Regex pSectVarRegex = new Regex(@"^(S(?:I|O)PARAM)_([1-9][0-9]*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
             StringBuilder b = new StringBuilder();
 
             int lastCopiedIdx = 0;
@@ -664,8 +668,7 @@ namespace PEBakery.Core
                     b.Append(s.ReturnValue);
                     continue;
                 }
-                else if (paramNameStr.Equals("SPARAM_COUNT", StringComparison.OrdinalIgnoreCase) ||
-                        paramNameStr.Equals("SIPARAM_COUNT", StringComparison.OrdinalIgnoreCase))
+                else if (paramNameStr.Equals("SIPARAM_COUNT", StringComparison.OrdinalIgnoreCase))
                 { // Expand Section In Params Count
                     b.Append(s.CurSectionInParamsCount);
                     continue;
@@ -701,8 +704,7 @@ namespace PEBakery.Core
                     if (!int.TryParse(pIdxStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out int pIdx))
                         throw new InternalException($"{nameof(ExpandPercentPatternSectionParams)} failure");
 
-                    if (pKind.Equals("SPARAM", StringComparison.OrdinalIgnoreCase) ||
-                        pKind.Equals("SIPARAM", StringComparison.OrdinalIgnoreCase))
+                    if (pKind.Equals("SIPARAM", StringComparison.OrdinalIgnoreCase))
                     { // Expand Section In Parameter
                         string param;
                         if (s.CurSectionInParams.TryGetValue(pIdx, out string? value))
@@ -714,7 +716,7 @@ namespace PEBakery.Core
                     }
                     else if (pKind.Equals("SOPARAM", StringComparison.OrdinalIgnoreCase))
                     { // Expand Section Out Parameter
-                        if (!s.CompatDisableLegacyExtendedSectionParams && s.CurSectionOutParams != null)
+                        if (s.CurSectionOutParams != null)
                         {
                             string param;
                             if (s.CurSectionInParams.TryGetValue(pIdx, out string? value))

--- a/PEBakery.Core/SyntaxChecker.cs
+++ b/PEBakery.Core/SyntaxChecker.cs
@@ -79,6 +79,11 @@ namespace PEBakery.Core
             Ex) Set,#c,Override
         10. Set is modifying interface control
             Is Set command overwriting current interface's control?
+        11. Reference of new percent-style parameters
+            - %^SPARAM%, %^SPARAM_COUNT% (Section In Parameter)
+            - %^SOPARAM%, %^SOPARAM_COUNT% (Section Out Parameter)
+            - %^RET% (Return Value)
+            - %^LOOP_IDX% (Loop Index)
         */
         #endregion
 
@@ -109,40 +114,37 @@ namespace PEBakery.Core
         #region CheckScript
         public (List<LogInfo>, Result) CheckScript()
         {
-            List<LogInfo> logs = new List<LogInfo>();
+            List<LogInfo> logs = [];
 
             // Deep inspect unknown sections to figure out hidden code sections.
             _sc.DeepInspectSections();
 
             // Codes
-            if (_sc.Sections.ContainsKey(ScriptSection.Names.Process))
-                logs.AddRange(CheckCodeSection(_sc.Sections[ScriptSection.Names.Process]));
+            if (_sc.Sections.TryGetValue(ScriptSection.Names.Process, out ScriptSection? codeSect))
+                logs.AddRange(CheckCodeSection(codeSect));
 
             // UICtrls - [Interface]
-            List<string> processedInterfaces = new List<string>();
-            if (_sc.Sections.ContainsKey(ScriptSection.Names.Interface))
+            List<string> processedInterfaces = [];
+            if (_sc.Sections.TryGetValue(ScriptSection.Names.Interface, out ScriptSection? ifaceSect))
             {
                 processedInterfaces.Add(ScriptSection.Names.Interface);
-                logs.AddRange(CheckInterfaceSection(_sc.Sections[ScriptSection.Names.Interface]));
+                logs.AddRange(CheckInterfaceSection(ifaceSect));
             }
             // UICtrls - Interface=
-            if (_sc.MainInfo.ContainsKey(ScriptSection.Names.Interface))
+            if (_sc.MainInfo.TryGetValue(ScriptSection.Names.Interface, out string? altInterfaceSectName))
             {
-                string ifaceSection = _sc.MainInfo[ScriptSection.Names.Interface];
-                processedInterfaces.Add(ifaceSection);
-                if (_sc.Sections.ContainsKey(ifaceSection))
-                    logs.AddRange(CheckInterfaceSection(_sc.Sections[ifaceSection]));
+                processedInterfaces.Add(altInterfaceSectName);
+                if (_sc.Sections.TryGetValue(altInterfaceSectName, out ScriptSection? altInterfaceSect))
+                    logs.AddRange(CheckInterfaceSection(altInterfaceSect));
                 else
-                    logs.Add(new LogInfo(LogState.Error, $"Section [{ifaceSection}] does not exist (Interface={ifaceSection})"));
+                    logs.Add(new LogInfo(LogState.Error, $"Section [{altInterfaceSectName}] does not exist (Interface={altInterfaceSectName})"));
             }
             // UICtrls - InterfaceList= (Stage 1)
-            if (_sc.MainInfo.ContainsKey(Script.Const.InterfaceList))
+            if (_sc.MainInfo.TryGetValue(Script.Const.InterfaceList, out string? ifaceSectNameList))
             {
-                // Check if InterfaceList contains proper sections
-                string interfaceList = _sc.MainInfo[Script.Const.InterfaceList];
                 try
                 {
-                    string? remainder = interfaceList;
+                    string? remainder = ifaceSectNameList;
                     while (remainder != null)
                     {
                         string next;
@@ -150,7 +152,7 @@ namespace PEBakery.Core
 
                         // Does this section exist?
                         if (!_sc.Sections.ContainsKey(next))
-                            logs.Add(new LogInfo(LogState.Error, $"Section [{next}] does not exist (InterfaceList={interfaceList})"));
+                            logs.Add(new LogInfo(LogState.Error, $"Section [{next}] does not exist (InterfaceList={ifaceSectNameList})"));
                     }
                 }
                 catch (InvalidCommandException e)
@@ -163,8 +165,8 @@ namespace PEBakery.Core
             foreach (string ifaceSection in _sc.GetInterfaceSectionNames(false)
                 .Where(x => !processedInterfaces.Contains(x, StringComparer.OrdinalIgnoreCase)))
             {
-                if (_sc.Sections.ContainsKey(ifaceSection))
-                    logs.AddRange(CheckInterfaceSection(_sc.Sections[ifaceSection]));
+                if (_sc.Sections.TryGetValue(ifaceSection, out ScriptSection? altInterfaceSect))
+                    logs.AddRange(CheckInterfaceSection(altInterfaceSect));
             }
 
             // Check more deep-inspected code sections
@@ -191,7 +193,7 @@ namespace PEBakery.Core
         {
             // If this section was already visited, return.
             if (_visitedSections.Contains(section.Name))
-                return new List<LogInfo>();
+                return [];
             _visitedSections.Add(section.Name);
 
             if (section.Lines == null)
@@ -202,7 +204,7 @@ namespace PEBakery.Core
                 if (0 < lineIdx)
                     msg += $" (Line {lineIdx})";
 
-                return new List<LogInfo> { new LogInfo(LogState.Error, msg) };
+                return [new LogInfo(LogState.Error, msg)];
             }
 
             CodeParser parser = new CodeParser(section, Global.Setting, section.Project.Compat);
@@ -375,16 +377,16 @@ namespace PEBakery.Core
 
                 if (targetCodeSection != null)
                 {
-                    if (_sc.Sections.ContainsKey(targetCodeSection))
-                        logs.AddRange(CheckCodeSection(_sc.Sections[targetCodeSection], cmd.RawCode, cmd.LineIdx));
+                    if (_sc.Sections.TryGetValue(targetCodeSection, out ScriptSection? codeSect))
+                        logs.AddRange(CheckCodeSection(codeSect, cmd.RawCode, cmd.LineIdx));
                     else
                         logs.Add(new LogInfo(LogState.Error, $"Section [{targetCodeSection}] does not exist", cmd));
                 }
 
                 if (targetInterfaceSection != null)
                 {
-                    if (_sc.Sections.ContainsKey(targetInterfaceSection))
-                        logs.AddRange(CheckInterfaceSection(_sc.Sections[targetInterfaceSection], cmd.RawCode, cmd.LineIdx));
+                    if (_sc.Sections.TryGetValue(targetInterfaceSection, out ScriptSection? ifaceSect))
+                        logs.AddRange(CheckInterfaceSection(ifaceSect, cmd.RawCode, cmd.LineIdx));
                     else
                         logs.Add(new LogInfo(LogState.Error, $"Interface section [{targetInterfaceSection}] does not exist", cmd));
                 }
@@ -397,7 +399,7 @@ namespace PEBakery.Core
         {
             // If this section was already visited, return.
             if (_visitedSections.Contains(section.Name))
-                return new List<LogInfo>();
+                return [];
             _visitedSections.Add(section.Name);
 
             // Force parsing of code, bypassing caching by section.GetUICtrls()
@@ -410,7 +412,7 @@ namespace PEBakery.Core
                 if (0 < lineIdx)
                     msg += $" (Line {lineIdx})";
 
-                return new List<LogInfo> { new LogInfo(LogState.Error, msg) };
+                return [new LogInfo(LogState.Error, msg)];
             }
 
             (List<UIControl> uiCtrls, List<LogInfo> logs) = UIParser.ParseStatements(lines, section);
@@ -424,8 +426,8 @@ namespace PEBakery.Core
 
                             if (info.SectionName != null)
                             {
-                                if (_sc.Sections.ContainsKey(info.SectionName)) // Only if section exists
-                                    logs.AddRange(CheckCodeSection(_sc.Sections[info.SectionName], uiCtrl.RawLine, uiCtrl.LineIdx));
+                                if (_sc.Sections.TryGetValue(info.SectionName, out ScriptSection? codeSect)) // Only if section exists
+                                    logs.AddRange(CheckCodeSection(codeSect, uiCtrl.RawLine, uiCtrl.LineIdx));
                                 else
                                     logs.Add(new LogInfo(LogState.Error, $"Section [{info.SectionName}] does not exist", uiCtrl));
                             }
@@ -441,8 +443,8 @@ namespace PEBakery.Core
 
                             if (info.SectionName != null)
                             {
-                                if (_sc.Sections.ContainsKey(info.SectionName)) // Only if section exists
-                                    logs.AddRange(CheckCodeSection(_sc.Sections[info.SectionName], uiCtrl.RawLine, uiCtrl.LineIdx));
+                                if (_sc.Sections.TryGetValue(info.SectionName, out ScriptSection? codeSect)) // Only if section exists
+                                    logs.AddRange(CheckCodeSection(codeSect, uiCtrl.RawLine, uiCtrl.LineIdx));
                                 else
                                     logs.Add(new LogInfo(LogState.Error, $"Section [{info.SectionName}] does not exist", uiCtrl));
                             }
@@ -465,7 +467,7 @@ namespace PEBakery.Core
                                 string url = StringEscaper.Unescape(info.Url);
                                 if (!StringEscaper.IsUrlValid(url))
                                 {
-                                    if (url.IndexOf("://", StringComparison.Ordinal) != -1)
+                                    if (url.Contains("://", StringComparison.Ordinal))
                                         logs.Add(new LogInfo(LogState.Warning, $"Incorrect URL [{url}]", uiCtrl));
                                     else
                                         logs.Add(new LogInfo(LogState.Warning, "URL does not have a scheme. Did you omit \"http(s)://\"?", uiCtrl));
@@ -498,8 +500,8 @@ namespace PEBakery.Core
 
                             if (info.SectionName != null)
                             {
-                                if (_sc.Sections.ContainsKey(info.SectionName)) // Only if section exists
-                                    logs.AddRange(CheckCodeSection(_sc.Sections[info.SectionName], uiCtrl.RawLine, uiCtrl.LineIdx));
+                                if (_sc.Sections.TryGetValue(info.SectionName, out ScriptSection? value)) // Only if section exists
+                                    logs.AddRange(CheckCodeSection(value, uiCtrl.RawLine, uiCtrl.LineIdx));
                                 else
                                     logs.Add(new LogInfo(LogState.Error, $"Section [{info.SectionName}] does not exist", uiCtrl));
                             }
@@ -514,7 +516,7 @@ namespace PEBakery.Core
                             string url = StringEscaper.Unescape(info.Url);
                             if (!StringEscaper.IsUrlValid(url))
                             {
-                                if (url.IndexOf("://", StringComparison.Ordinal) != -1)
+                                if (url.Contains("://", StringComparison.Ordinal))
                                     logs.Add(new LogInfo(LogState.Warning, $"Incorrect URL [{url}]", uiCtrl));
                                 else
                                     logs.Add(new LogInfo(LogState.Warning, "URL does not have a scheme. Did you omit \"http(s)://\"?", uiCtrl));
@@ -527,8 +529,8 @@ namespace PEBakery.Core
 
                             if (info.SectionName != null)
                             {
-                                if (_sc.Sections.ContainsKey(info.SectionName)) // Only if section exists
-                                    logs.AddRange(CheckCodeSection(_sc.Sections[info.SectionName], uiCtrl.RawLine, uiCtrl.LineIdx));
+                                if (_sc.Sections.TryGetValue(info.SectionName, out ScriptSection? codeSect)) // Only if section exists
+                                    logs.AddRange(CheckCodeSection(codeSect, uiCtrl.RawLine, uiCtrl.LineIdx));
                                 else
                                     logs.Add(new LogInfo(LogState.Error, $"Section [{info.SectionName}] does not exist", uiCtrl));
                             }
@@ -560,8 +562,8 @@ namespace PEBakery.Core
 
                             if (info.SectionName != null)
                             {
-                                if (_sc.Sections.ContainsKey(info.SectionName)) // Only if section exists
-                                    logs.AddRange(CheckCodeSection(_sc.Sections[info.SectionName], uiCtrl.RawLine, uiCtrl.LineIdx));
+                                if (_sc.Sections.TryGetValue(info.SectionName, out ScriptSection? codeSect)) // Only if section exists
+                                    logs.AddRange(CheckCodeSection(codeSect, uiCtrl.RawLine, uiCtrl.LineIdx));
                                 else
                                     logs.Add(new LogInfo(LogState.Error, $"Section [{info.SectionName}] does not exist", uiCtrl));
                             }
@@ -592,8 +594,8 @@ namespace PEBakery.Core
 
                             if (info.SectionName != null)
                             {
-                                if (_sc.Sections.ContainsKey(info.SectionName)) // Only if section exists
-                                    logs.AddRange(CheckCodeSection(_sc.Sections[info.SectionName], uiCtrl.RawLine, uiCtrl.LineIdx));
+                                if (_sc.Sections.TryGetValue(info.SectionName, out ScriptSection? codeSect)) // Only if section exists
+                                    logs.AddRange(CheckCodeSection(codeSect, uiCtrl.RawLine, uiCtrl.LineIdx));
                                 else
                                     logs.Add(new LogInfo(LogState.Error, $"Section [{info.SectionName}] does not exist", uiCtrl));
                             }

--- a/PEBakery.Core/UIControl.cs
+++ b/PEBakery.Core/UIControl.cs
@@ -558,12 +558,12 @@ namespace PEBakery.Core
             }
         );
 
-        public static HashSet<UIControlType> HasInterfaceEncodedFile { get; } = new HashSet<UIControlType>()
-        {
+        public static HashSet<UIControlType> HasInterfaceEncodedFile { get; } =
+        [
             UIControlType.Image,
             UIControlType.TextFile,
             UIControlType.Button,
-        };
+        ];
         #endregion
 
         #region Template

--- a/PEBakery.Core/Variables.cs
+++ b/PEBakery.Core/Variables.cs
@@ -633,44 +633,25 @@ namespace PEBakery.Core
 
                     if (_opts.OverridableFixedVariables)
                     { // WinBuilder compatible
-                        if (_localVars.ContainsKey(varName))
-                        {
-                            string localVarValue = _localVars[varName];
+                        if (_localVars.TryGetValue(varName, out string? localVarValue))
                             b.Append(localVarValue);
-                        }
-                        else if (_globalVars.ContainsKey(varName))
-                        {
-                            string varValue = _globalVars[varName];
-                            b.Append(varValue);
-                        }
-                        else if (_fixedVars.ContainsKey(varName))
-                        {
-                            string varValue = _fixedVars[varName];
-                            b.Append(varValue);
-                        }
+                        else if (_globalVars.TryGetValue(varName, out string? globalVarValue))
+                            b.Append(globalVarValue);
+                        else if (_fixedVars.TryGetValue(varName, out string? fixedVarValue))
+                            b.Append(fixedVarValue);
                         else // variable not found
-                        {
                             b.Append("#$p").Append(varName).Append("#$p");
-                        }
                     }
                     else
                     { // PEBakery standard
                         if (_fixedVars.TryGetValue(varName, out string? fixedVarValue))
-                        {
                             b.Append(fixedVarValue);
-                        }
                         else if (_localVars.TryGetValue(varName, out string? localVarValue))
-                        {
                             b.Append(localVarValue);
-                        }
                         else if (_globalVars.TryGetValue(varName, out string? globalVarValue))
-                        {
                             b.Append(globalVarValue);
-                        }
                         else // variable not found
-                        {
                             b.Append("#$p").Append(varName).Append("#$p");
-                        }
                     }
 
                     if (x + 1 == matches.Count) // Last iteration
@@ -771,7 +752,7 @@ namespace PEBakery.Core
         /// <returns></returns>
         public static string? GetVariableName(EngineState s, string varName)
         {
-            if (!varName.StartsWith("%") || !varName.EndsWith("%"))
+            if (!varName.StartsWith('%') || !varName.EndsWith('%'))
                 return null;
             if (StringHelper.CountSubStr(varName, "%") != 2)
                 return null;
@@ -780,8 +761,8 @@ namespace PEBakery.Core
         }
 
         public const string VarKeyRegexContainsVariable = @"(%[a-zA-Z0-9_\-#\(\)\.]+%)";
-        public const string VarKeyRegexContainsLegacySectionInParams = @"(#[1-9])";
-        public const string VarKeyRegexContainsLegacySectionOutParams = @"(#[oO][1-9])";
+        public const string VarKeyRegexContainsLegacySectionInParams = @"#([1-9])";
+        public const string VarKeyRegexContainsLegacySectionOutParams = @"#[oO]([1-9])";
         public const string VarKeyRegexContainsPercentSectionInParams = @"%\^SIPARAM_([1-9][0-9_]*)%";
         public const string VarKeyRegexContainsPercentSectionOutParams = @"%\^SOPARAM_([1-9][0-9_]*)%";
         public const string VarKeyRegexVariable = @"^" + VarKeyRegexContainsVariable + @"$";
@@ -827,7 +808,7 @@ namespace PEBakery.Core
             Match match = Regex.Match(secParam, VarKeyRegexContainsPercentSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
             if (match.Success)
             {
-                if (NumberHelper.ParseInt32(secParam[1..], out int paramIdx))
+                if (NumberHelper.ParseInt32(match.Groups[1].Value, out int paramIdx))
                     return paramIdx;
                 else
                     return 0; // Error
@@ -855,7 +836,7 @@ namespace PEBakery.Core
             Match match = Regex.Match(secParam, VarKeyRegexContainsPercentSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
             if (match.Success)
             {
-                if (NumberHelper.ParseInt32(secParam[2..], out int paramIdx))
+                if (NumberHelper.ParseInt32(match.Groups[1].Value, out int paramIdx))
                     return paramIdx;
                 else
                     return 0; // Error
@@ -1068,14 +1049,21 @@ namespace PEBakery.Core
                 }
                 else if (type == VarKeyType.ReturnValueLegacy) // #r
                 { // s.SectionReturnValue's default value is string.Empty
-                    if (!s.CompatDisableLegacyExtendedSectionParams)
+                    if (s.CompatEnableAllLegacySectionParams)
                     {
-                        s.ReturnValue = string.Empty;
-                        logs.Add(new LogInfo(LogState.Success, "ReturnValue [#r] deleted"));
+                        if (!s.CompatDisableLegacyExtendedSectionParams)
+                        {
+                            s.ReturnValue = string.Empty;
+                            logs.Add(new LogInfo(LogState.Success, "ReturnValue [#r] deleted"));
+                        }
+                        else
+                        {
+                            logs.Add(new LogInfo(LogState.Warning, "ReturnValue [#r] is disabled by the compatibility option"));
+                        }
                     }
                     else
                     {
-                        logs.Add(new LogInfo(LogState.Ignore, "ReturnValue [#r] is disabled by the compatibility option"));
+                        logs.Add(new LogInfo(LogState.Warning, "Legacy section parameters are not enabled by the compatibility option"));
                     }
                 }
                 else if (type == VarKeyType.LoopCounterPercent) // %^LOOP_IDX%
@@ -1122,7 +1110,7 @@ namespace PEBakery.Core
                         LogInfo log = s.Variables.SetValue(VarsType.Global, key, finalValue);
                         logs.Add(log);
 
-                        // Remove local variable if exist
+                        // Remove local variable if it exists
                         if (log.State == LogState.Success)
                             s.Variables.DeleteKey(VarsType.Local, key);
                     }
@@ -1238,7 +1226,7 @@ namespace PEBakery.Core
                         return logs;
                     }
 
-                    // Escape #c (Loop Counter)
+                    // Escape Loop Counter
                     if (0 < s.LoopCmdStateStack.Count)
                     {
                         EngineLoopCmdState peekLoop = s.LoopCmdStateStack.Peek();

--- a/PEBakery.Core/Variables.cs
+++ b/PEBakery.Core/Variables.cs
@@ -635,8 +635,8 @@ namespace PEBakery.Core
                     { // WinBuilder compatible
                         if (_localVars.ContainsKey(varName))
                         {
-                            string varValue = _localVars[varName];
-                            b.Append(varValue);
+                            string localVarValue = _localVars[varName];
+                            b.Append(localVarValue);
                         }
                         else if (_globalVars.ContainsKey(varName))
                         {
@@ -655,20 +655,17 @@ namespace PEBakery.Core
                     }
                     else
                     { // PEBakery standard
-                        if (_fixedVars.ContainsKey(varName))
+                        if (_fixedVars.TryGetValue(varName, out string? fixedVarValue))
                         {
-                            string varValue = _fixedVars[varName];
-                            b.Append(varValue);
+                            b.Append(fixedVarValue);
                         }
-                        else if (_localVars.ContainsKey(varName))
+                        else if (_localVars.TryGetValue(varName, out string? localVarValue))
                         {
-                            string varValue = _localVars[varName];
-                            b.Append(varValue);
+                            b.Append(localVarValue);
                         }
-                        else if (_globalVars.ContainsKey(varName))
+                        else if (_globalVars.TryGetValue(varName, out string? globalVarValue))
                         {
-                            string varValue = _globalVars[varName];
-                            b.Append(varValue);
+                            b.Append(globalVarValue);
                         }
                         else // variable not found
                         {

--- a/PEBakery.Core/Variables.cs
+++ b/PEBakery.Core/Variables.cs
@@ -780,30 +780,51 @@ namespace PEBakery.Core
         }
 
         public const string VarKeyRegexContainsVariable = @"(%[a-zA-Z0-9_\-#\(\)\.]+%)";
-        public const string VarKeyRegexContainsSectionInParams = @"(#[1-9])";
-        public const string VarKeyRegexContainsSectionOutParams = @"(#[oO][1-9])";
+        public const string VarKeyRegexContainsLegacySectionInParams = @"(#[1-9])";
+        public const string VarKeyRegexContainsLegacySectionOutParams = @"(#[oO][1-9])";
+        public const string VarKeyRegexContainsPercentSectionInParams = @"%\^SIPARAM_([1-9][0-9_]*)%";
+        public const string VarKeyRegexContainsPercentSectionOutParams = @"%\^SOPARAM_([1-9][0-9_]*)%";
         public const string VarKeyRegexVariable = @"^" + VarKeyRegexContainsVariable + @"$";
-        public const string VarKeyRegexSectionInParams = @"^" + VarKeyRegexContainsSectionInParams + @"$";
-        public const string VarKeyRegexSectionOutParams = @"^" + VarKeyRegexContainsSectionOutParams + @"$";
-        public enum VarKeyType { None, Variable, SectionInParams, SectionOutParams, ReturnValue, LoopCounter }
+        public const string VarKeyRegexLegacySectionInParams = @"^" + VarKeyRegexContainsLegacySectionInParams + @"$";
+        public const string VarKeyRegexLegacySectionOutParams = @"^" + VarKeyRegexContainsLegacySectionOutParams + @"$";
+        public const string VarKeyRegexPercentSectionInParams = @"^" + VarKeyRegexContainsPercentSectionInParams + @"$";
+        public const string VarKeyRegexPercentSectionOutParams = @"^" + VarKeyRegexContainsPercentSectionOutParams + @"$";
+        public enum VarKeyType
+        {
+            None,
+            Variable,
+            SectionInParamsPercent, SectionInParamsLegacy,
+            SectionOutParamsPercent, SectionOutParamsLegacy,
+            ReturnValuePercent, ReturnValueLegacy,
+            LoopCounterPercent, LoopCounterLegacy
+        }
+
         public static VarKeyType DetectType(string key)
         {
             if (Regex.Match(key, VarKeyRegexVariable, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) %A%
                 return VarKeyType.Variable;  // %#[0-9]+% -> Compatibility Shim
-            if (Regex.Match(key, VarKeyRegexSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) #1, #2, #3, ...
-                return VarKeyType.SectionInParams;
-            if (Regex.Match(key, VarKeyRegexSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) #o1, #o2, #o3, ...
-                return VarKeyType.SectionOutParams;
+            if (Regex.Match(key, VarKeyRegexPercentSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) %^SIPARAM_1%, %^SIPARAM_1%, ...
+                return VarKeyType.SectionInParamsPercent;
+            if (Regex.Match(key, VarKeyRegexLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) #1, #2, #3, ...
+                return VarKeyType.SectionInParamsLegacy;
+            if (Regex.Match(key, VarKeyRegexPercentSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) %^SOPARAM_1%, %^SOPARAM_2%, %^SOPARAM_3% ...
+                return VarKeyType.SectionOutParamsPercent;
+            if (Regex.Match(key, VarKeyRegexLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) #o1, #o2, #o3, ...
+                return VarKeyType.SectionOutParamsLegacy;
+            if (key.Equals("%^RET%", StringComparison.OrdinalIgnoreCase)) // Return Value
+                return VarKeyType.ReturnValuePercent;
             if (key.Equals("#r", StringComparison.OrdinalIgnoreCase)) // Return Value
-                return VarKeyType.ReturnValue;
+                return VarKeyType.ReturnValueLegacy;
+            if (key.Equals("%^LOOP_IDX%", StringComparison.OrdinalIgnoreCase)) // Loop Counter
+                return VarKeyType.LoopCounterPercent;
             if (key.Equals("#c", StringComparison.OrdinalIgnoreCase)) // Loop Counter
-                return VarKeyType.LoopCounter;
+                return VarKeyType.LoopCounterLegacy;
             return VarKeyType.None;
         }
 
-        public static int GetSectionInParamIndex(string secParam)
+        public static int GetPercentSectionInParamIndex(string secParam)
         {
-            Match match = Regex.Match(secParam, VarKeyRegexContainsSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match match = Regex.Match(secParam, VarKeyRegexContainsPercentSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
             if (match.Success)
             {
                 if (NumberHelper.ParseInt32(secParam[1..], out int paramIdx))
@@ -815,9 +836,23 @@ namespace PEBakery.Core
             return 0; // Error
         }
 
-        public static int GetSectionOutParamIndex(string secParam)
+        public static int GetLegacySectionInParamIndex(string secParam)
         {
-            Match match = Regex.Match(secParam, VarKeyRegexContainsSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match match = Regex.Match(secParam, VarKeyRegexContainsLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            if (match.Success)
+            {
+                if (NumberHelper.ParseInt32(secParam[1..], out int paramIdx))
+                    return paramIdx;
+                else
+                    return 0; // Error
+            }
+
+            return 0; // Error
+        }
+
+        public static int GetPercentSectionOutParamIndex(string secParam)
+        {
+            Match match = Regex.Match(secParam, VarKeyRegexContainsPercentSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
             if (match.Success)
             {
                 if (NumberHelper.ParseInt32(secParam[2..], out int paramIdx))
@@ -829,12 +864,26 @@ namespace PEBakery.Core
             return 0; // Error
         }
 
-        public static string? GetSectionOutParamVarKey(EngineState s, string secParam)
+        public static int GetLegacySectionOutParamIndex(string secParam)
+        {
+            Match match = Regex.Match(secParam, VarKeyRegexContainsLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            if (match.Success)
+            {
+                if (NumberHelper.ParseInt32(secParam[2..], out int paramIdx))
+                    return paramIdx;
+                else
+                    return 0; // Error
+            }
+
+            return 0; // Error
+        }
+
+        public static string? GetPercentSectionOutParamVarKey(EngineState s, string secParam)
         {
             if (s.CurSectionOutParams == null)
                 return null;
 
-            int soIdx = GetSectionOutParamIndex(secParam);
+            int soIdx = GetPercentSectionOutParamIndex(secParam);
             if (soIdx == 0)
                 return null; // Error
             if (s.CurSectionOutParams.Count == 0 || s.CurSectionOutParams.Count < soIdx)
@@ -843,47 +892,73 @@ namespace PEBakery.Core
             return s.CurSectionOutParams[soIdx - 1]; // %Dest%
         }
 
-        public static LogInfo SetSectionInParam(EngineState s, string key, string value)
+        public static string? GetLegacySectionOutParamVarKey(EngineState s, string secParam)
         {
-            int pIdx = GetSectionInParamIndex(key);
-            return SetSectionInParam(s, pIdx, value);
+            if (s.CurSectionOutParams == null)
+                return null;
+
+            int soIdx = GetLegacySectionOutParamIndex(secParam);
+            if (soIdx == 0)
+                return null; // Error
+            if (s.CurSectionOutParams.Count == 0 || s.CurSectionOutParams.Count < soIdx)
+                return null;
+
+            return s.CurSectionOutParams[soIdx - 1]; // %Dest%
         }
 
-        public static LogInfo SetSectionInParam(EngineState s, int pIdx, string value)
+        public static LogInfo SetPercentSectionInParam(EngineState s, string key, string value)
+        {
+            int pIdx = GetPercentSectionInParamIndex(key);
+            return SetSectionInParamInternal(s, pIdx, value, $"%^SIPARAM_{pIdx}%");
+        }
+
+        public static LogInfo SetLegacySectionInParam(EngineState s, string key, string value)
+        {
+            int pIdx = GetLegacySectionInParamIndex(key);
+            return SetSectionInParamInternal(s, pIdx, value, $"#{pIdx}");
+        }
+
+        private static LogInfo SetSectionInParamInternal(EngineState s, int pIdx, string value, string symbol)
         {
             if (pIdx <= 0)
                 return new LogInfo(LogState.Error, $"Section parameter's index [{pIdx}] must be a positive integer");
-            if (value.IndexOf($"#{pIdx}", StringComparison.Ordinal) != -1)
+            if (value.Contains($"#{pIdx}", StringComparison.Ordinal))
                 return new LogInfo(LogState.Error, "Section parameter cannot have a circular reference");
 
             s.CurSectionInParams[pIdx] = value;
-            return new LogInfo(LogState.Success, $"Section parameter [#{pIdx}] set to [{value}]");
+            return new LogInfo(LogState.Success, $"Section parameter [{symbol}] set to [{value}]");
         }
 
-        public static LogInfo SetSectionOutParam(EngineState s, string key, string value)
+        public static LogInfo SetPercentSectionOutParam(EngineState s, string key, string value)
         {
-            int pIdx = GetSectionOutParamIndex(key);
-            return SetSectionOutParam(s, pIdx, value);
+            int pIdx = GetPercentSectionOutParamIndex(key);
+            return SetSectionOutParamInternal(s, pIdx, value, $"%^SOPARAM_{pIdx}%");
         }
 
-        public static LogInfo SetSectionOutParam(EngineState s, int pIdx, string value)
+        public static LogInfo SetLegacySectionOutParam(EngineState s, string key, string value)
         {
+            int pIdx = GetLegacySectionOutParamIndex(key);
+            return SetSectionOutParamInternal(s, pIdx, value, $"#o{pIdx}");
+        }
+
+        private static LogInfo SetSectionOutParamInternal(EngineState s, int pIdx, string value, string symbol)
+        { // [%^SOPARAM_{pIdx}%]
             // pIdx starts from 1 
             if (pIdx <= 0)
                 return new LogInfo(LogState.Error, $"Section out parameter's index [{pIdx}] must be a positive integer");
-            if (value.IndexOf($"#o{pIdx}", StringComparison.OrdinalIgnoreCase) != -1)
+            if (value.Contains($"#o{pIdx}", StringComparison.OrdinalIgnoreCase))
                 return new LogInfo(LogState.Error, "Section out parameter cannot have a circular reference");
             if (s.CurSectionOutParams == null || s.CurSectionOutParams.Count == 0 || s.CurSectionOutParams.Count <= pIdx - 1)
-                return new LogInfo(LogState.Error, $"[#o{pIdx}] is not referencing any variables");
+                return new LogInfo(LogState.Error, $"[{symbol}] is not referencing any variables");
 
             // Write to varKey
             string varKey = s.CurSectionOutParams[pIdx - 1]; // %Dest%
             string? key = GetVariableName(s, varKey); // %D%
             if (key == null) // This must not happen, must check before calling this method
-                return new LogInfo(LogState.CriticalError, $"[#o{pIdx}] is referencing invalid variable");
+                return new LogInfo(LogState.CriticalError, $"[{symbol}] is referencing invalid variable");
 
             s.Variables.SetValue(VarsType.Local, key, value);
-            return new LogInfo(LogState.Success, $"[{varKey}], reference of [#o{pIdx}], set to [{value}]");
+            return new LogInfo(LogState.Success, $"[{varKey}], reference of [{symbol}], set to [{value}]");
         }
 
         /// <summary>
@@ -937,11 +1012,8 @@ namespace PEBakery.Core
 
                             // https://github.com/pebakery/pebakery/issues/88
                             // Delete variable line from memory-cached MainScript
-                            if (s.Project.MainScript.Sections.ContainsKey(ScriptSection.Names.Variables))
-                            {
-                                ScriptSection varSect = s.Project.MainScript.Sections[ScriptSection.Names.Variables];
-                                varSect.DeleteIniKey($"%{key}%");
-                            }
+                            if (s.Project.MainScript.Sections.TryGetValue(ScriptSection.Names.Variables, out ScriptSection? mainVarSect))
+                                mainVarSect.DeleteIniKey($"%{key}%");
                         }
                         else
                         {
@@ -960,18 +1032,41 @@ namespace PEBakery.Core
                             logs.Add(new LogInfo(LogState.Ignore, $"Variable [%{key}%] does not exist"));
                     }
                 }
-                else if (type == VarKeyType.SectionInParams) // #1, #2, #3, ...
+                else if (type == VarKeyType.SectionInParamsPercent) // %^SIPARAM_1%, %SIPARAM_2%, ...
                 { // WB082 does not remove section parameter, just set to string "NIL"
-                    logs.Add(SetSectionInParam(s, varKey, finalValue));
+                    logs.Add(SetPercentSectionInParam(s, varKey, finalValue));
                 }
-                else if (type == VarKeyType.SectionOutParams) // #o1, #o2, #o3, ...
+                else if (type == VarKeyType.SectionInParamsLegacy) // #1, #2, #3, ...
                 { // WB082 does not remove section parameter, just set to string "NIL"
-                    if (!s.CompatDisableLegacyExtendedSectionParams)
-                        logs.Add(SetSectionOutParam(s, varKey, finalValue));
+                    if (s.CompatEnableAllLegacySectionParams)
+                        logs.Add(SetLegacySectionInParam(s, varKey, finalValue));
                     else
-                        logs.Add(new LogInfo(LogState.Warning, "Section out parameters are disabled by the compatibility option"));
+                        logs.Add(new LogInfo(LogState.Warning, "Legacy section parameters are not enabled by the compatibility option"));
                 }
-                else if (type == VarKeyType.ReturnValue) // #r
+                else if (type == VarKeyType.SectionOutParamsPercent) // %SOPARAM_1%, %SOPARAM_2%, %SOPARAM_3%, ...
+                { // WB082 does not remove section parameter, just set to string "NIL"
+                    logs.Add(SetPercentSectionOutParam(s, varKey, finalValue));
+                }
+                else if (type == VarKeyType.SectionOutParamsLegacy) // #o1, #o2, #o3, ...
+                { // WB082 does not remove section parameter, just set to string "NIL"
+                    if (s.CompatEnableAllLegacySectionParams)
+                    {
+                        if (!s.CompatDisableLegacyExtendedSectionParams)
+                            logs.Add(SetLegacySectionOutParam(s, varKey, finalValue));
+                        else
+                            logs.Add(new LogInfo(LogState.Warning, "Legacy section out parameters are disabled by the compatibility option"));
+                    }
+                    else
+                    {
+                        logs.Add(new LogInfo(LogState.Warning, "Legacy section parameters are not enabled by the compatibility option"));
+                    }
+                }
+                else if (type == VarKeyType.ReturnValuePercent) // %^RET^%
+                {
+                    s.ReturnValue = string.Empty;
+                    logs.Add(new LogInfo(LogState.Success, "ReturnValue [%^RET%] deleted"));
+                }
+                else if (type == VarKeyType.ReturnValueLegacy) // #r
                 { // s.SectionReturnValue's default value is string.Empty
                     if (!s.CompatDisableLegacyExtendedSectionParams)
                     {
@@ -983,9 +1078,16 @@ namespace PEBakery.Core
                         logs.Add(new LogInfo(LogState.Ignore, "ReturnValue [#r] is disabled by the compatibility option"));
                     }
                 }
-                else if (type == VarKeyType.LoopCounter)
-                { // #c
-                    logs.Add(new LogInfo(LogState.Warning, "LoopCounter [#c] cannot be deleted"));
+                else if (type == VarKeyType.LoopCounterPercent) // %^LOOP_IDX%
+                {
+                    logs.Add(new LogInfo(LogState.Warning, "LoopCounter [%^LOOP_IDX%] cannot be deleted"));
+                }
+                else if (type == VarKeyType.LoopCounterLegacy) // #c
+                {
+                    if (s.CompatEnableAllLegacySectionParams)
+                        logs.Add(new LogInfo(LogState.Warning, "LoopCounter [#c] cannot be deleted"));
+                    else
+                        logs.Add(new LogInfo(LogState.Warning, "Legacy section parameters are not enabled by the compatibility option"));
                 }
                 else
                 {
@@ -1038,16 +1140,14 @@ namespace PEBakery.Core
 
                             // https://github.com/pebakery/pebakery/issues/88
                             // Update memory-cached MainScript's Variables section 
-                            if (s.Project.MainScript.Sections.ContainsKey(ScriptSection.Names.Variables))
+                            if (s.Project.MainScript.Sections.TryGetValue(ScriptSection.Names.Variables, out ScriptSection? mainVarSect))
                             {
-                                ScriptSection varSect = s.Project.MainScript.Sections[ScriptSection.Names.Variables];
-                                varSect.UpdateIniKey($"%{key}%", finalValue);
+                                mainVarSect.UpdateIniKey($"%{key}%", finalValue);
                             }
                             else
                             { // Create temp ScriptSection instance
                                 ScriptSection varSect = new ScriptSection(
-                                    s.Project.MainScript, ScriptSection.Names.Variables, SectionType.Variables,
-                                    new string[] { $"%{key}%={finalValue}" }, 0);
+                                    s.Project.MainScript, ScriptSection.Names.Variables, SectionType.Variables, [$"%{key}%={finalValue}"], 0);
                                 s.Project.MainScript.Sections[ScriptSection.Names.Variables] = varSect;
                             }
 
@@ -1064,34 +1164,77 @@ namespace PEBakery.Core
                         logs.Add(s.Variables.SetValue(VarsType.Local, key, finalValue));
                     }
                 }
-                else if (type == VarKeyType.SectionInParams) // #1, #2, #3, ...
+                else if (type == VarKeyType.SectionInParamsPercent) // %^SIPARAM_1%, %SIPARAM_2%, ...
                 {
-                    logs.Add(SetSectionInParam(s, varKey, finalValue));
+                    logs.Add(SetPercentSectionInParam(s, varKey, finalValue));
                 }
-                else if (type == VarKeyType.SectionOutParams) // #o1, #o2, #o3, ...
+                else if (type == VarKeyType.SectionInParamsLegacy) // #1, #2, #3, ...
                 {
-                    if (!s.CompatDisableLegacyExtendedSectionParams)
-                        logs.Add(SetSectionOutParam(s, varKey, finalValue));
+                    if (s.CompatEnableAllLegacySectionParams)
+                        logs.Add(SetLegacySectionInParam(s, varKey, finalValue));
                     else
-                        logs.Add(new LogInfo(LogState.Warning, "Section out parameters are disabled by the compatibility option"));
+                        logs.Add(new LogInfo(LogState.Warning, "Legacy section parameters are not enabled by the compatibility option"));
                 }
-                else if (type == VarKeyType.ReturnValue) // #r
+                else if (type == VarKeyType.SectionOutParamsPercent) // %SOPARAM_1%, %SOPARAM_2%, %SOPARAM_3%, ...
                 {
-                    if (!s.CompatDisableLegacyExtendedSectionParams)
+                    logs.Add(SetPercentSectionOutParam(s, varKey, finalValue));
+                }
+                else if (type == VarKeyType.SectionOutParamsLegacy) // #o1, #o2, #o3, ...
+                {
+                    if (s.CompatEnableAllLegacySectionParams)
                     {
-                        s.ReturnValue = finalValue;
-                        logs.Add(new LogInfo(LogState.Success, $"ReturnValue [#r] set to [{finalValue}]"));
+                        if (!s.CompatDisableLegacyExtendedSectionParams)
+                            logs.Add(SetLegacySectionOutParam(s, varKey, finalValue));
+                        else
+                            logs.Add(new LogInfo(LogState.Warning, "Legacy section out parameters are disabled by the compatibility option"));
                     }
                     else
                     {
-                        logs.Add(new LogInfo(LogState.Warning, "ReturnValue [#r] is disabled by the compatibility option"));
+                        logs.Add(new LogInfo(LogState.Warning, "Legacy section parameters are not enabled by the compatibility option"));
                     }
                 }
-                else if (type == VarKeyType.LoopCounter)
-                { // #c
+                else if (type == VarKeyType.ReturnValuePercent) // %^RET^%
+                {
+                    s.ReturnValue = finalValue;
+                    logs.Add(new LogInfo(LogState.Success, $"ReturnValue [%^RET%] set to [{finalValue}]"));
+                }
+                else if (type == VarKeyType.ReturnValueLegacy) // #r
+                {
+                    if (s.CompatEnableAllLegacySectionParams)
+                    {
+                        if (!s.CompatDisableLegacyExtendedSectionParams)
+                        {
+                            s.ReturnValue = finalValue;
+                            logs.Add(new LogInfo(LogState.Success, $"ReturnValue [#r] set to [{finalValue}]"));
+                        }
+                        else
+                        {
+                            logs.Add(new LogInfo(LogState.Warning, "ReturnValue [#r] is disabled by the compatibility option"));
+                        }
+                    }
+                    else
+                    {
+                        logs.Add(new LogInfo(LogState.Warning, "Legacy section parameters are not enabled by the compatibility option"));
+                    }
+                }
+                else if (type == VarKeyType.LoopCounterPercent || // %^LOOP_IDX%
+                        type == VarKeyType.LoopCounterLegacy) // #c
+                {
+                    string symbol = "%^LOOP_IDX%";
+                    if (type == VarKeyType.LoopCounterLegacy)
+                    {
+                        symbol = "#c";
+
+                        if (!s.CompatEnableAllLegacySectionParams)
+                        {
+                            logs.Add(new LogInfo(LogState.Warning, "Legacy section parameters are not enabled by the compatibility option"));
+                            return logs;
+                        }
+                    }
+
                     if (!s.CompatOverridableLoopCounter)
                     {
-                        logs.Add(new LogInfo(LogState.Warning, "LoopCounter [#c] cannot be overriden"));
+                        logs.Add(new LogInfo(LogState.Warning, $"LoopCounter [{symbol}] cannot be overriden"));
                         return logs;
                     }
 
@@ -1113,7 +1256,7 @@ namespace PEBakery.Core
                                 s.LoopCmdStateStack.Pop();
                                 s.LoopCmdStateStack.Push(idxLoop);
 
-                                logs.Add(new LogInfo(LogState.Success, $"LoopCounter [#c] set to [{ctr}]"));
+                                logs.Add(new LogInfo(LogState.Success, $"LoopCounter [{symbol}] set to [{ctr}]"));
                                 break;
                             case LoopCmdState.OnDriveLetter:
                                 if (!(finalValue.Length == 1 && StringHelper.IsAlphabet(finalValue[0])))
@@ -1128,13 +1271,13 @@ namespace PEBakery.Core
                                 s.LoopCmdStateStack.Pop();
                                 s.LoopCmdStateStack.Push(charLoop);
 
-                                logs.Add(new LogInfo(LogState.Success, $"LoopCounter [#c] set to [{charLoop.CounterLetter}]"));
+                                logs.Add(new LogInfo(LogState.Success, $"LoopCounter [{symbol}] set to [{charLoop.CounterLetter}]"));
                                 break;
                         }
                     }
                     else
                     {
-                        logs.Add(new LogInfo(LogState.Error, "Loop is not running, unable to update LoopCounter [#c]"));
+                        logs.Add(new LogInfo(LogState.Error, $"Loop is not running, unable to update LoopCounter [{symbol}]"));
                         return logs;
                     }
                 }
@@ -1155,24 +1298,42 @@ namespace PEBakery.Core
         /// <returns>Return null at error</returns>
         public static bool? ContainsKey(EngineState s, string varKey)
         {
-            if (varKey == null)
-                throw new ArgumentNullException(nameof(varKey));
+            ArgumentNullException.ThrowIfNull(varKey);
 
             VarKeyType type = DetectType(varKey);
             switch (type)
             {
                 case VarKeyType.Variable:
-                    string? key = TrimPercentMark(varKey);
-                    return key != null && s.Variables.ContainsKey(key);
-                case VarKeyType.SectionInParams:
-                    int siIdx = GetSectionInParamIndex(varKey);
-                    return siIdx != 0 && s.CurSectionInParams.ContainsKey(siIdx);
-                case VarKeyType.SectionOutParams:
-                    if (GetSectionOutParamVarKey(s, varKey) is not string newVarKey)
-                        return null;
-                    varKey = newVarKey;
-                    goto case VarKeyType.Variable;
-                case VarKeyType.ReturnValue:
+                    {
+                        string? key = TrimPercentMark(varKey);
+                        return key != null && s.Variables.ContainsKey(key);
+                    }
+                case VarKeyType.SectionInParamsPercent:
+                    {
+                        int siIdx = GetPercentSectionInParamIndex(varKey);
+                        return siIdx != 0 && s.CurSectionInParams.ContainsKey(siIdx);
+                    }
+                case VarKeyType.SectionInParamsLegacy:
+                    {
+                        int siIdx = GetLegacySectionInParamIndex(varKey);
+                        return siIdx != 0 && s.CurSectionInParams.ContainsKey(siIdx);
+                    }
+                case VarKeyType.SectionOutParamsPercent:
+                    {
+                        if (GetPercentSectionOutParamVarKey(s, varKey) is not string newVarKey)
+                            return null;
+                        varKey = newVarKey;
+                        goto case VarKeyType.Variable;
+                    }
+                case VarKeyType.SectionOutParamsLegacy:
+                    {
+                        if (GetLegacySectionOutParamVarKey(s, varKey) is not string newVarKey)
+                            return null;
+                        varKey = newVarKey;
+                        goto case VarKeyType.Variable;
+                    }
+                case VarKeyType.ReturnValuePercent:
+                case VarKeyType.ReturnValueLegacy:
                     return true;
                 default:
                     return null;

--- a/PEBakery.Core/Variables.cs
+++ b/PEBakery.Core/Variables.cs
@@ -966,14 +966,14 @@ namespace PEBakery.Core
                 }
                 else if (type == VarKeyType.SectionOutParams) // #o1, #o2, #o3, ...
                 { // WB082 does not remove section parameter, just set to string "NIL"
-                    if (!s.CompatDisableExtendedSectionParams)
+                    if (!s.CompatDisableLegacyExtendedSectionParams)
                         logs.Add(SetSectionOutParam(s, varKey, finalValue));
                     else
                         logs.Add(new LogInfo(LogState.Warning, "Section out parameters are disabled by the compatibility option"));
                 }
                 else if (type == VarKeyType.ReturnValue) // #r
                 { // s.SectionReturnValue's default value is string.Empty
-                    if (!s.CompatDisableExtendedSectionParams)
+                    if (!s.CompatDisableLegacyExtendedSectionParams)
                     {
                         s.ReturnValue = string.Empty;
                         logs.Add(new LogInfo(LogState.Success, "ReturnValue [#r] deleted"));
@@ -1070,14 +1070,14 @@ namespace PEBakery.Core
                 }
                 else if (type == VarKeyType.SectionOutParams) // #o1, #o2, #o3, ...
                 {
-                    if (!s.CompatDisableExtendedSectionParams)
+                    if (!s.CompatDisableLegacyExtendedSectionParams)
                         logs.Add(SetSectionOutParam(s, varKey, finalValue));
                     else
                         logs.Add(new LogInfo(LogState.Warning, "Section out parameters are disabled by the compatibility option"));
                 }
                 else if (type == VarKeyType.ReturnValue) // #r
                 {
-                    if (!s.CompatDisableExtendedSectionParams)
+                    if (!s.CompatDisableLegacyExtendedSectionParams)
                     {
                         s.ReturnValue = finalValue;
                         logs.Add(new LogInfo(LogState.Success, $"ReturnValue [#r] set to [{finalValue}]"));

--- a/PEBakery.Helper.Tests/SilentDictParserTests.cs
+++ b/PEBakery.Helper.Tests/SilentDictParserTests.cs
@@ -33,9 +33,26 @@ namespace PEBakery.Helper.Tests
     public class SilentDictParserTests
     {
         #region Test Dictionary, Enum
-        private static readonly Dictionary<string, string?> TestDict = new Dictionary<string, string?>(StringComparer.Ordinal)
+        private static readonly Dictionary<string, string?> NullableTestDict = new Dictionary<string, string?>(StringComparer.Ordinal)
         {
             ["Null"] = null,
+            ["Str"] = "ing",
+            ["Int1"] = "100",
+            ["Int2"] = "0x100",
+            ["Int3"] = "-1",
+            ["StrEnum1"] = "First",
+            ["StrEnum2"] = "sECOND",
+            ["StrEnum3"] = "LAST",
+            ["IntEnum1"] = "0x10",
+            ["IntEnum2"] = "0x02",
+            ["IntEnum3"] = "0x40",
+            ["Color1"] = "230, 0, 0",
+            ["Color2"] = "16, 32, 64",
+            ["Color3"] = "0xFF, 0xA0, 0",
+        };
+
+        private static readonly Dictionary<string, string> NonNullableTestDict = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
             ["Str"] = "ing",
             ["Int1"] = "100",
             ["Int2"] = "0x100",
@@ -62,70 +79,228 @@ namespace PEBakery.Helper.Tests
 
         #region ParseString
         [TestMethod]
-        [TestCategory("Helper")]
-        [TestCategory("SilentDictParser")]
         public void ParseString()
         {
-            string? result = SilentDictParser.ParseStringNullable(TestDict, "Str", "Default");
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result.Equals("ing", StringComparison.Ordinal));
-            result = SilentDictParser.ParseStringNullDefault(TestDict, "Str", null);
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result.Equals("ing", StringComparison.Ordinal));
-            result = SilentDictParser.ParseStringNullable(TestDict, "None", "Default");
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result.Equals("Default", StringComparison.Ordinal));
-            result = SilentDictParser.ParseStringNullDefault(TestDict, "None", null);
-            Assert.IsNull(result);
-            result = SilentDictParser.ParseStringNullable(TestDict, "Null", "Default");
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result.Equals("Default", StringComparison.Ordinal));
-            result = SilentDictParser.ParseStringNullDefault(TestDict, "Null", null);
-            Assert.IsNull(result);
+            // Non-Nullable
+            {
+                string result = SilentDictParser.ParseString(NonNullableTestDict, "Str", "Default");
+                Assert.IsTrue(result.Equals("ing", StringComparison.Ordinal));
+                result = SilentDictParser.ParseString(NonNullableTestDict, "None", "Default");
+                Assert.IsTrue(result.Equals("Default", StringComparison.Ordinal));
+                result = SilentDictParser.ParseString(NonNullableTestDict, "Color3", "Default");
+                Assert.IsTrue(result.Equals("0xFF, 0xA0, 0", StringComparison.Ordinal));
+            }
+
+            // Nullable
+            {
+                string? result = SilentDictParser.ParseStringNullable(NullableTestDict, "Str", "Default");
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Equals("ing", StringComparison.Ordinal));
+                result = SilentDictParser.ParseStringNullDefault(NullableTestDict, "Str", null);
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Equals("ing", StringComparison.Ordinal));
+                result = SilentDictParser.ParseStringNullable(NullableTestDict, "None", "Default");
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Equals("Default", StringComparison.Ordinal));
+                result = SilentDictParser.ParseStringNullDefault(NullableTestDict, "None", null);
+                Assert.IsNull(result);
+                result = SilentDictParser.ParseStringNullable(NullableTestDict, "Null", "Default");
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Equals("Default", StringComparison.Ordinal));
+                result = SilentDictParser.ParseStringNullDefault(NullableTestDict, "Null", null);
+                Assert.IsNull(result);
+            }
+        }
+
+        [TestMethod]
+        public void ParseStringFallback()
+        {
+            // Non-Nullable with fallbackKeys
+            {
+                string result = SilentDictParser.ParseString(NonNullableTestDict, "Str", ["Int1", "Color1"], "Default");
+                Assert.IsTrue(result.Equals("ing", StringComparison.Ordinal));
+                result = SilentDictParser.ParseString(NonNullableTestDict, "None", ["Int1", "Color1"], "Default");
+                Assert.IsTrue(result.Equals("100", StringComparison.Ordinal));
+                result = SilentDictParser.ParseString(NonNullableTestDict, "None", ["Invalid", "Color1"], "Default");
+                Assert.IsTrue(result.Equals("230, 0, 0", StringComparison.Ordinal));
+                result = SilentDictParser.ParseString(NonNullableTestDict, "None", ["Invalid"], "Default");
+                Assert.IsTrue(result.Equals("Default", StringComparison.Ordinal));
+            }
+            
+            // Nullable with fallbackKeys
+            {
+                string? result = SilentDictParser.ParseStringNullable(NullableTestDict, "Str", ["Int1", "Color1"], "Default");
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Equals("ing", StringComparison.Ordinal));
+                result = SilentDictParser.ParseStringNullDefault(NullableTestDict, "None", ["Int1", "Color1"], null);
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Equals("100", StringComparison.Ordinal));
+                result = SilentDictParser.ParseStringNullable(NullableTestDict, "None", ["Invalid", "Color1"], "Default");
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.Equals("230, 0, 0", StringComparison.Ordinal));
+                result = SilentDictParser.ParseStringNullDefault(NullableTestDict, "None", ["Invalid"], null);
+                Assert.IsNull(result);
+            }
         }
         #endregion
 
         #region ParseInteger
         [TestMethod]
-        [TestCategory("Helper")]
-        [TestCategory("SilentDictParser")]
         public void ParseInteger()
         {
-            // With incorrectValue
+            // With unparsableValue + Without nullable
             {
-                int result = SilentDictParser.ParseIntegerNullable(TestDict, "Int1", 0, out bool incorrectValue);
+                int result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int1", 0, out bool unparsableValue);
                 Assert.AreEqual(100, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "Int2", 0, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int2", 0, out unparsableValue);
                 Assert.AreEqual(0x100, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "Int3", 0, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int3", 0, out unparsableValue);
                 Assert.AreEqual(-1, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "None", 0, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "None", 0, out unparsableValue);
                 Assert.AreEqual(0, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "None", -128, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "None", -128, out unparsableValue);
                 Assert.AreEqual(-128, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "Str", 128, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Str", 128, out unparsableValue);
                 Assert.AreEqual(128, result);
-                Assert.IsTrue(incorrectValue);
+                Assert.IsTrue(unparsableValue);
             }
 
-            // Without incorrectValue
+            // Without unparsableValue + Without nullable
             {
-                int result = SilentDictParser.ParseIntegerNullable(TestDict, "Int1", 0);
+                int result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int1", 0);
                 Assert.AreEqual(100, result);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "Int2", 0);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int2", 0);
                 Assert.AreEqual(0x100, result);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "Int3", 0);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int3", 0);
                 Assert.AreEqual(-1, result);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "None", 0);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "None", 0);
                 Assert.AreEqual(0, result);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "None", -128);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "None", -128);
                 Assert.AreEqual(-128, result);
-                result = SilentDictParser.ParseIntegerNullable(TestDict, "Str", 128);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Str", 128);
+                Assert.AreEqual(128, result);
+            }
+
+            // With unparsableValue + With nullable
+            {
+                int result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int1", 0, out bool unparsableValue);
+                Assert.AreEqual(100, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int2", 0, out unparsableValue);
+                Assert.AreEqual(0x100, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int3", 0, out unparsableValue);
+                Assert.AreEqual(-1, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "None", 0, out unparsableValue);
+                Assert.AreEqual(0, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "None", -128, out unparsableValue);
+                Assert.AreEqual(-128, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Str", 128, out unparsableValue);
+                Assert.AreEqual(128, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + With nullable
+            {
+                int result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int1", 0);
+                Assert.AreEqual(100, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int2", 0);
+                Assert.AreEqual(0x100, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int3", 0);
+                Assert.AreEqual(-1, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "None", 0);
+                Assert.AreEqual(0, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "None", -128);
+                Assert.AreEqual(-128, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Str", 128);
+                Assert.AreEqual(128, result);
+            }
+        }
+
+        [TestMethod]
+        public void ParseIntegerFallback()
+        {
+            // With unparsableValue + Without nullable
+            {
+                int result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int1", ["Int2", "Int3"], 0, out bool unparsableValue);
+                Assert.AreEqual(100, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int4", ["Int2", "Int3"], 0, out unparsableValue);
+                Assert.AreEqual(0x100, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int3", [], 0, out unparsableValue);
+                Assert.AreEqual(-1, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "None", [], 0, out unparsableValue);
+                Assert.AreEqual(0, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "None", [], -128, out unparsableValue);
+                Assert.AreEqual(-128, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Str", ["Int3"], 128, out unparsableValue);
+                Assert.AreEqual(128, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + Without nullable
+            {
+                int result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int1", ["Int2", "Int3"], 0);
+                Assert.AreEqual(100, result);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int4", ["Int2", "Int3"], 0);
+                Assert.AreEqual(0x100, result);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Int3", [], 0);
+                Assert.AreEqual(-1, result);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "None", [], 0);
+                Assert.AreEqual(0, result);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "None", [],  -128);
+                Assert.AreEqual(-128, result);
+                result = SilentDictParser.ParseInteger(NonNullableTestDict, "Str", ["Int3"], 128);
+                Assert.AreEqual(128, result);
+            }
+
+            // With unparsableValue + With nullable
+            {
+                int result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int1", ["Int2", "Int3"], 0, out bool unparsableValue);
+                Assert.AreEqual(100, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int4", ["Int2", "Int3"], 0, out unparsableValue);
+                Assert.AreEqual(0x100, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int3", [], 0, out unparsableValue);
+                Assert.AreEqual(-1, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "None", [], 0, out unparsableValue);
+                Assert.AreEqual(0, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "None", [], -128, out unparsableValue);
+                Assert.AreEqual(-128, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Str", ["Int3"], 128, out unparsableValue);
+                Assert.AreEqual(128, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + With nullable
+            {
+                int result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int1", ["Int2", "Int3"], 0);
+                Assert.AreEqual(100, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int2", ["Int2", "Int3"], 0);
+                Assert.AreEqual(0x100, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Int3", [], 0);
+                Assert.AreEqual(-1, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "None", [], 0);
+                Assert.AreEqual(0, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "None", [], -128);
+                Assert.AreEqual(-128, result);
+                result = SilentDictParser.ParseIntegerNullable(NullableTestDict, "Str", ["Int3"], 128);
                 Assert.AreEqual(128, result);
             }
         }
@@ -133,45 +308,161 @@ namespace PEBakery.Helper.Tests
 
         #region ParseStrEnum
         [TestMethod]
-        [TestCategory("Helper")]
-        [TestCategory("SilentDictParser")]
         public void ParseStrEnum()
         {
-            // With incorrectValue
+            // With unparsableValue + Without Nullable
             {
-                TestEnum result = SilentDictParser.ParseStrEnumNullable(TestDict, "StrEnum1", TestEnum.None, out bool incorrectValue);
+                TestEnum result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum1", TestEnum.None, out bool unparsableValue);
                 Assert.AreEqual(TestEnum.First, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "StrEnum2", TestEnum.None, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum2", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.Second, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "StrEnum3", TestEnum.None, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum3", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.None, result);
-                Assert.IsTrue(incorrectValue);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "None", TestEnum.None, out incorrectValue);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "None", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.None, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "Null", TestEnum.None, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "Null", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.None, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "Int3", TestEnum.None, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "Int3", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.None, result);
-                Assert.IsTrue(incorrectValue);
+                Assert.IsTrue(unparsableValue);
             }
 
-            // Without incorrectValue
+            // Without unparsableValue + Without Nullable
             {
-                TestEnum result = SilentDictParser.ParseStrEnumNullable(TestDict, "StrEnum1", TestEnum.None);
+                TestEnum result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum1", TestEnum.None);
                 Assert.AreEqual(TestEnum.First, result);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "StrEnum2", TestEnum.None);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum2", TestEnum.None);
                 Assert.AreEqual(TestEnum.Second, result);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "StrEnum3", TestEnum.None);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum3", TestEnum.None);
                 Assert.AreEqual(TestEnum.None, result);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "None", TestEnum.None);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "None", TestEnum.None);
                 Assert.AreEqual(TestEnum.None, result);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "Null", TestEnum.None);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "Null", TestEnum.None);
                 Assert.AreEqual(TestEnum.None, result);
-                result = SilentDictParser.ParseStrEnumNullable(TestDict, "Int3", TestEnum.None);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "Int3", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+            }
+
+            // With unparsableValue + With Nullable
+            {
+                TestEnum result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum1", TestEnum.None, out bool unparsableValue);
+                Assert.AreEqual(TestEnum.First, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum2", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.Second, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum3", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "None", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "Null", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "Int3", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + With Nullable
+            {
+                TestEnum result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum1", TestEnum.None);
+                Assert.AreEqual(TestEnum.First, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum2", TestEnum.None);
+                Assert.AreEqual(TestEnum.Second, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum3", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "None", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "Null", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "Int3", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+            }
+        }
+
+        [TestMethod]
+        public void ParseStrEnumFallback()
+        {
+            // With unparsableValue + Without Nullable
+            {
+                TestEnum result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum1", ["StrEnum2", "StrEnum3"], TestEnum.None, out bool unparsableValue);
+                Assert.AreEqual(TestEnum.First, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum4", ["StrEnum2", "StrEnum3"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.Second, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum3", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "None", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "Null", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "Int3", ["Str3"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + Without Nullable
+            {
+                TestEnum result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum1", ["StrEnum2", "StrEnum3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.First, result);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum4", ["StrEnum2", "StrEnum3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.Second, result);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "StrEnum3", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "None", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "Null", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnum(NonNullableTestDict, "Int3", ["Str3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+            }
+
+            // With unparsableValue + With Nullable
+            {
+                TestEnum result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum1", ["StrEnum2", "StrEnum3"], TestEnum.None, out bool unparsableValue);
+                Assert.AreEqual(TestEnum.First, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum4", ["StrEnum2", "StrEnum3"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.Second, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum3", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "None", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "Null", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "Int3", ["Str3"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + With Nullable
+            {
+                TestEnum result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum1", ["StrEnum2", "StrEnum3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.First, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum4", ["StrEnum2", "StrEnum3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.Second, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "StrEnum3", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "None", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "Null", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseStrEnumNullable(NullableTestDict, "Int3", ["Str3"], TestEnum.None);
                 Assert.AreEqual(TestEnum.None, result);
             }
         }
@@ -179,95 +470,325 @@ namespace PEBakery.Helper.Tests
 
         #region ParseIntEnum
         [TestMethod]
-        [TestCategory("Helper")]
-        [TestCategory("SilentDictParser")]
         public void ParseIntEnum()
         {
-            // With incorrectValue
+            // With unparsableValue + Without Nullable
             {
-                TestEnum result = SilentDictParser.ParseIntEnumNullable(TestDict, "IntEnum1", TestEnum.None, out bool incorrectValue);
+                TestEnum result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum1", TestEnum.None, out bool unparsableValue);
                 Assert.AreEqual(TestEnum.First, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "IntEnum2", TestEnum.None, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum2", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.None, result);
-                Assert.IsTrue(incorrectValue);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "IntEnum3", TestEnum.None, out incorrectValue);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum3", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.Third, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "None", TestEnum.None, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "None", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.None, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "Null", TestEnum.None, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "Null", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.None, result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "StrEnum3", TestEnum.None, out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "StrEnum3", TestEnum.None, out unparsableValue);
                 Assert.AreEqual(TestEnum.None, result);
-                Assert.IsTrue(incorrectValue);
+                Assert.IsTrue(unparsableValue);
             }
 
-            // Without incorrectValue
+            // Without unparsableValue + Without Nullable
             {
-                TestEnum result = SilentDictParser.ParseIntEnumNullable(TestDict, "IntEnum1", TestEnum.None);
+                TestEnum result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum1", TestEnum.None);
                 Assert.AreEqual(TestEnum.First, result);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "IntEnum2", TestEnum.None);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum2", TestEnum.None);
                 Assert.AreEqual(TestEnum.None, result);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "IntEnum3", TestEnum.None);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum3", TestEnum.None);
                 Assert.AreEqual(TestEnum.Third, result);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "None", TestEnum.None);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "None", TestEnum.None);
                 Assert.AreEqual(TestEnum.None, result);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "Null", TestEnum.None);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "Null", TestEnum.None);
                 Assert.AreEqual(TestEnum.None, result);
-                result = SilentDictParser.ParseIntEnumNullable(TestDict, "StrEnum3", TestEnum.None);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "StrEnum3", TestEnum.None);
                 Assert.AreEqual(TestEnum.None, result);
             }
-            
+
+            // With unparsableValue + With Nullable
+            {
+                TestEnum result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum1", TestEnum.None, out bool unparsableValue);
+                Assert.AreEqual(TestEnum.First, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum2", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum3", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.Third, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "None", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "Null", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "StrEnum3", TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + With Nullable
+            {
+                TestEnum result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum1", TestEnum.None);
+                Assert.AreEqual(TestEnum.First, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum2", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum3", TestEnum.None);
+                Assert.AreEqual(TestEnum.Third, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "None", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "Null", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "StrEnum3", TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+            }
+        }
+
+        [TestMethod]
+        public void ParseIntEnumFallback()
+        {
+            // With unparsableValue + Without Nullable
+            {
+                TestEnum result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum1", ["IntEnum2", "IntEnum3"], TestEnum.None, out bool unparsableValue);
+                Assert.AreEqual(TestEnum.First, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum4", ["IntEnum2", "IntEnum3"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum3", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.Third, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "None", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "None", ["IntEnum1"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.First, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "StrEnum3", ["IntEnum1"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + Without Nullable
+            {
+                TestEnum result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum1", ["IntEnum2", "IntEnum3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.First, result);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum4", ["IntEnum2", "IntEnum3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "IntEnum3", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.Third, result);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "None", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "None", ["IntEnum1"], TestEnum.None);
+                Assert.AreEqual(TestEnum.First, result);
+                result = SilentDictParser.ParseIntEnum(NonNullableTestDict, "StrEnum3", ["IntEnum1"], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+            }
+
+            // With unparsableValue + With Nullable
+            {
+                TestEnum result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum1", ["IntEnum2", "IntEnum3"], TestEnum.None, out bool unparsableValue);
+                Assert.AreEqual(TestEnum.First, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum4", ["IntEnum2", "IntEnum3"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum3", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.Third, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "None", [], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "None", ["IntEnum1"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.First, result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "StrEnum3", ["IntEnum1"], TestEnum.None, out unparsableValue);
+                Assert.AreEqual(TestEnum.None, result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + With Nullable
+            {
+                TestEnum result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum1", ["IntEnum2", "IntEnum3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.First, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum4", ["IntEnum2", "IntEnum3"], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "IntEnum3", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.Third, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "None", [], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "None", ["IntEnum1"], TestEnum.None);
+                Assert.AreEqual(TestEnum.First, result);
+                result = SilentDictParser.ParseIntEnumNullable(NullableTestDict, "StrEnum3", ["IntEnum1"], TestEnum.None);
+                Assert.AreEqual(TestEnum.None, result);
+            }
         }
         #endregion
 
         #region ParseColor
         [TestMethod]
-        [TestCategory("Helper")]
-        [TestCategory("SilentDictParser")]
         public void ParseColor()
         {
-            // With incorrectValue
+            // With unparsableValue + Without Nullable
             {
-                Color result = SilentDictParser.ParseColorNullable(TestDict, "Color1", Color.FromRgb(255, 255, 255), out bool incorrectValue);
+                Color result = SilentDictParser.ParseColor(NonNullableTestDict, "Color1", Color.FromRgb(255, 255, 255), out bool unparsableValue);
                 Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseColorNullable(TestDict, "Color2", Color.FromRgb(255, 255, 255), out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Color2", Color.FromRgb(255, 255, 255), out unparsableValue);
                 Assert.AreEqual(Color.FromRgb(16, 32, 64), result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseColorNullable(TestDict, "Color3", Color.FromRgb(255, 255, 255), out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Color3", Color.FromRgb(255, 255, 255), out unparsableValue);
                 Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
-                Assert.IsTrue(incorrectValue);
-                result = SilentDictParser.ParseColorNullable(TestDict, "None", Color.FromRgb(255, 255, 255), out incorrectValue);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "None", Color.FromRgb(255, 255, 255), out unparsableValue);
                 Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseColorNullable(TestDict, "Null", Color.FromRgb(255, 255, 255), out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Null", Color.FromRgb(255, 255, 255), out unparsableValue);
                 Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
-                Assert.IsFalse(incorrectValue);
-                result = SilentDictParser.ParseColorNullable(TestDict, "Str", Color.FromRgb(255, 255, 255), out incorrectValue);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Str", Color.FromRgb(255, 255, 255), out unparsableValue);
                 Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
-                Assert.IsTrue(incorrectValue);
+                Assert.IsTrue(unparsableValue);
             }
 
-            // Without incorrectValue
+            // Without unparsableValue + Without Nullable
             {
-                Color result = result = SilentDictParser.ParseColorNullable(TestDict, "Color1", Color.FromRgb(255, 255, 255));
+                Color result = SilentDictParser.ParseColor(NonNullableTestDict, "Color1", Color.FromRgb(255, 255, 255));
                 Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
-                result = SilentDictParser.ParseColorNullable(TestDict, "Color2", Color.FromRgb(255, 255, 255));
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Color2", Color.FromRgb(255, 255, 255));
                 Assert.AreEqual(Color.FromRgb(16, 32, 64), result);
-                result = SilentDictParser.ParseColorNullable(TestDict, "Color3", Color.FromRgb(255, 255, 255));
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Color3", Color.FromRgb(255, 255, 255));
                 Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
-                result = SilentDictParser.ParseColorNullable(TestDict, "None", Color.FromRgb(255, 255, 255));
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "None", Color.FromRgb(255, 255, 255));
                 Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
-                result = SilentDictParser.ParseColorNullable(TestDict, "Null", Color.FromRgb(255, 255, 255));
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Null", Color.FromRgb(255, 255, 255));
                 Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
-                result = SilentDictParser.ParseColorNullable(TestDict, "Str", Color.FromRgb(255, 255, 255));
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Str", Color.FromRgb(255, 255, 255));
                 Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
             }
-            
+
+            // With unparsableValue + With Nullable
+            {
+                Color result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color1", Color.FromRgb(255, 255, 255), out bool unparsableValue);
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color2", Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(16, 32, 64), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color3", Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "None", Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Null", Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Str", Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + With Nullable
+            {
+                Color result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color1", Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color2", Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(16, 32, 64), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color3", Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "None", Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Null", Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Str", Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+            }
+        }
+
+        [TestMethod]
+        public void ParseColorFallback()
+        {
+            // With unparsableValue + Without Nullable
+            {
+                Color result = SilentDictParser.ParseColor(NonNullableTestDict, "Color1", ["Color2", "Color3"], Color.FromRgb(255, 255, 255), out bool unparsableValue);
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Color4", ["Color2", "Color3"], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(16, 32, 64), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Color3", [], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "None", [], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "None", ["Color1"], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Str", [], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + Without Nullable
+            {
+                Color result = SilentDictParser.ParseColor(NonNullableTestDict, "Color1", ["Color2", "Color3"], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Color4", ["Color2", "Color3"], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(16, 32, 64), result);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Color3", [], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "None", [], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "None", ["Color1"], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                result = SilentDictParser.ParseColor(NonNullableTestDict, "Str", [], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+            }
+
+            // With unparsableValue + With Nullable
+            {
+                Color result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color1", ["Color2", "Color3"], Color.FromRgb(255, 255, 255), out bool unparsableValue);
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color4", ["Color2", "Color3"], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(16, 32, 64), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color3", [], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsTrue(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "None", [], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "None", ["Color1"], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                Assert.IsFalse(unparsableValue);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Str", [], Color.FromRgb(255, 255, 255), out unparsableValue);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                Assert.IsTrue(unparsableValue);
+            }
+
+            // Without unparsableValue + With Nullable
+            {
+                Color result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color1", ["Color2", "Color3"], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color4", ["Color2", "Color3"], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(16, 32, 64), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Color3", [], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "None", [], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "None", ["Color1"], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(230, 0, 0), result);
+                result = SilentDictParser.ParseColorNullable(NullableTestDict, "Str", [], Color.FromRgb(255, 255, 255));
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), result);
+            }
         }
         #endregion
     }

--- a/PEBakery.Helper/SilentDictParser.cs
+++ b/PEBakery.Helper/SilentDictParser.cs
@@ -42,15 +42,42 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="key">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <returns>Parsed boolean value.</returns>
         public static string ParseString(Dictionary<string, string> dict, string key, string defaultValue)
         {
-            if (!dict.ContainsKey(key))
-                return defaultValue;
+            // Try to get a value from primary key.
+            if (dict.TryGetValue(key, out string? valStr) && valStr is not null)
+                return valStr;
 
-            return dict[key];
+            return defaultValue;
+        }
+
+        /// <summary>
+        /// Parse a boolean value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini value.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed boolean value.</returns>
+        public static string ParseString(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, string defaultValue)
+        {
+            // Try to get a value from primary key.
+            if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is not null)
+                return priValStr;
+
+            // Try to get a value from fallback keys.
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is not null)
+                    return fallbackValStr;
+            }
+
+            return defaultValue;
         }
         #endregion
 
@@ -62,18 +89,41 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="key">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <returns>Parsed boolean value.</returns>
         public static string ParseStringNullable(Dictionary<string, string?> dict, string key, string defaultValue)
         {
-            if (!dict.ContainsKey(key))
-                return defaultValue;
+            if (dict.TryGetValue(key, out string? priValStr) && priValStr is not null)
+                return priValStr;
 
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            return defaultValue;
+        }
 
-            return valStr;
+        /// <summary>
+        /// Parse a boolean value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini value.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed boolean value.</returns>
+        public static string ParseStringNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, string defaultValue)
+        {
+            // Try to get a value from primary key.
+            if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is not null)
+                return priValStr;
+
+            // Try to get a value from fallback keys.
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is not null)
+                    return fallbackValStr;
+            }
+
+            return defaultValue;
         }
         #endregion
 
@@ -85,18 +135,42 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="key">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <returns>Parsed boolean value.</returns>
         public static string? ParseStringNullDefault(Dictionary<string, string?> dict, string key, string? defaultValue)
         {
-            if (!dict.ContainsKey(key))
-                return defaultValue;
+            // Try to get a value from primary key.
+            if (dict.TryGetValue(key, out string? priValStr) && priValStr is not null)
+                return priValStr;
 
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            return defaultValue;
+        }
 
-            return valStr;
+        /// <summary>
+        /// Parse a boolean value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini value.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed boolean value.</returns>
+        public static string? ParseStringNullDefault(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, string? defaultValue)
+        {
+            // Try to get a value from primary key.
+            if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is not null)
+                return priValStr;
+
+            // Try to get a value from fallback keys.
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is not null)
+                    return fallbackValStr;
+            }
+
+            return defaultValue;
         }
         #endregion
 
@@ -108,7 +182,7 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="key">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <returns>Parsed boolean value.</returns>
         public static bool ParseBoolean(Dictionary<string, string> dict, string key, bool defaultValue)
@@ -123,31 +197,77 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="primaryKey">Name of the ini value.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed boolean value.</returns>
+        public static bool ParseBoolean(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, bool defaultValue)
+        {
+            return ParseBoolean(dict, primaryKey, fallbackKeys, defaultValue, out _);
+        }
+
+        /// <summary>
+        /// Parse a boolean value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed boolean value.</returns>
-        public static bool ParseBoolean(Dictionary<string, string> dict, string key, bool defaultValue, out bool incorrectValue)
+        public static bool ParseBoolean(Dictionary<string, string> dict, string primaryKey, bool defaultValue, out bool incorrectValue)
         {
-            // Check ContainsKey and null
             incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            if (dict.TryGetValue(primaryKey, out string? valRawStr) && valRawStr is string valStr)
+            {
+                if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                    return true;
+                else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
 
             incorrectValue = true;
-            bool val;
-            if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
-                val = true;
-            else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
-                val = false;
-            else
-                return defaultValue;
+            return defaultValue;
+        }
 
+        /// <summary>
+        /// Parse a boolean value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini value.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed boolean value.</returns>
+        public static bool ParseBoolean(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, bool defaultValue, out bool incorrectValue)
+        {
             incorrectValue = false;
-            return val;
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                        return true;
+                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                        return true;
+                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
         #endregion
 
@@ -159,7 +279,7 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="key">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <returns>Parsed boolean value.</returns>
         public static bool ParseBooleanNullable(Dictionary<string, string?> dict, string key, bool defaultValue)
@@ -174,31 +294,79 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="primaryKey">Name of the ini value.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed boolean value.</returns>
+        public static bool ParseBooleanNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, bool defaultValue)
+        {
+            return ParseBooleanNullable(dict, primaryKey, fallbackKeys, defaultValue, out _);
+        }
+
+        /// <summary>
+        /// Parse a boolean value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="key">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed boolean value.</returns>
         public static bool ParseBooleanNullable(Dictionary<string, string?> dict, string key, bool defaultValue, out bool incorrectValue)
         {
-            // Check ContainsKey and null
             incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            {
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                        return true;
+                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+            }
 
             incorrectValue = true;
-            bool val;
-            if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
-                val = true;
-            else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
-                val = false;
-            else
-                return defaultValue;
+            return defaultValue;
+        }
 
+        /// <summary>
+        /// Parse a boolean value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini value.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed boolean value.</returns>
+        public static bool ParseBooleanNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, bool defaultValue, out bool incorrectValue)
+        {
             incorrectValue = false;
-            return val;
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                        return true;
+                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                        return true;
+                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
         #endregion
 
@@ -215,7 +383,22 @@ namespace PEBakery.Helper
         /// <returns>Parsed int value.</returns>
         public static int ParseInteger(Dictionary<string, string> dict, string key, int defaultValue)
         {
-            return ParseInteger(dict, key, defaultValue, null, null, out _);
+            return ParseIntegerWithinRange(dict, key, defaultValue, null, null, out _);
+        }
+
+        /// <summary>
+        /// Parse an int value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed int value.</returns>
+        public static int ParseInteger(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue)
+        {
+            return ParseIntegerWithinRange(dict, primaryKey, fallbackKeys, defaultValue, null, null, out _);
         }
 
         /// <summary>
@@ -230,9 +413,9 @@ namespace PEBakery.Helper
         /// <param name="min">Allowed minimal integer value.</param>
         /// <param name="max">Allowed maximum integer value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseInteger(Dictionary<string, string> dict, string key, int defaultValue, int? min, int? max)
+        public static int ParseIntegerWithinRange(Dictionary<string, string> dict, string key, int defaultValue, int? min, int? max)
         {
-            return ParseInteger(dict, key, defaultValue, min, max, out _);
+            return ParseIntegerWithinRange(dict, key, defaultValue, min, max, out _);
         }
 
         /// <summary>
@@ -242,13 +425,30 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="min">Allowed minimal integer value.</param>
+        /// <param name="max">Allowed maximum integer value.</param>
+        /// <returns>Parsed int value.</returns>
+        public static int ParseIntegerWithinRange(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, int? min, int? max)
+        {
+            return ParseIntegerWithinRange(dict, primaryKey, fallbackKeys, defaultValue, min, max, out _);
+        }
+
+        /// <summary>
+        /// Parse an int value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseInteger(Dictionary<string, string> dict, string key, int defaultValue, out bool incorrectValue)
+        public static int ParseInteger(Dictionary<string, string> dict, string primaryKey, int defaultValue, out bool incorrectValue)
         {
-            return ParseInteger(dict, key, defaultValue, null, null, out incorrectValue);
+            return ParseIntegerWithinRange(dict, primaryKey, defaultValue, null, null, out incorrectValue);
         }
 
         /// <summary>
@@ -258,33 +458,99 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="key">Name of the ini section.</param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed int value.</returns>
+        public static int ParseInteger(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, out bool incorrectValue)
+        {
+            return ParseIntegerWithinRange(dict, primaryKey, fallbackKeys, defaultValue, null, null, out incorrectValue);
+        }
+
+        /// <summary>
+        /// Parse an int value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="min">Allowed minimal integer value.</param>
         /// <param name="max">Allowed maximum integer value.</param>
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseInteger(Dictionary<string, string> dict, string key, int defaultValue, int? min, int? max, out bool incorrectValue)
+        public static int ParseIntegerWithinRange(Dictionary<string, string> dict, string primaryKey, int defaultValue, int? min, int? max, out bool incorrectValue)
         {
-            // Check ContainsKey and null
             incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt))
+                    {
+                        if (min is int minVal && valInt < minVal)
+                            return minVal;
+                        else if (max is int maxVal && maxVal < valInt)
+                            return maxVal;
+                        else
+                            return valInt;
+                    }
+                }
+            }
 
             incorrectValue = true;
-            if (!NumberHelper.ParseInt32(valStr, out int valInt))
-                return defaultValue;
+            return defaultValue;
+        }
 
-            if (min is int minVal && valInt < minVal)
-                return minVal;
-            if (max is int maxVal && maxVal < valInt)
-                return maxVal;
-
+        /// <summary>
+        /// Parse an int value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="min">Allowed minimal integer value.</param>
+        /// <param name="max">Allowed maximum integer value.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed int value.</returns>
+        public static int ParseIntegerWithinRange(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, int? min, int? max, out bool incorrectValue)
+        {
             incorrectValue = false;
-            return valInt;
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt))
+                    {
+                        if (min is int minVal && valInt < minVal)
+                            return minVal;
+                        else if (max is int maxVal && maxVal < valInt)
+                            return maxVal;
+                        else
+                            return valInt;
+                    }
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt))
+                    {
+                        if (min is int minVal && valInt < minVal)
+                            return minVal;
+                        else if (max is int maxVal && maxVal < valInt)
+                            return maxVal;
+                        else
+                            return valInt;
+                    }
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
         #endregion
 
@@ -301,7 +567,22 @@ namespace PEBakery.Helper
         /// <returns>Parsed int value.</returns>
         public static int ParseIntegerNullable(Dictionary<string, string?> dict, string key, int defaultValue)
         {
-            return ParseIntegerNullable(dict, key, defaultValue, null, null, out _);
+            return ParseIntegerWithinRangeNullable(dict, key, defaultValue, null, null, out _);
+        }
+
+        /// <summary>
+        /// Parse an int value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed int value.</returns>
+        public static int ParseIntegerNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue)
+        {
+            return ParseIntegerWithinRangeNullable(dict, primaryKey, fallbackKeys, defaultValue, null, null, out _);
         }
 
         /// <summary>
@@ -316,9 +597,26 @@ namespace PEBakery.Helper
         /// <param name="min">Allowed minimal integer value.</param>
         /// <param name="max">Allowed maximum integer value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseIntegerNullable(Dictionary<string, string?> dict, string key, int defaultValue, int? min, int? max)
+        public static int ParseIntegerWithinRangeNullable(Dictionary<string, string?> dict, string key, int defaultValue, int? min, int? max)
         {
-            return ParseIntegerNullable(dict, key, defaultValue, min, max, out _);
+            return ParseIntegerWithinRangeNullable(dict, key, defaultValue, min, max, out _);
+        }
+
+        /// <summary>
+        /// Parse an int value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="min">Allowed minimal integer value.</param>
+        /// <param name="max">Allowed maximum integer value.</param>
+        /// <returns>Parsed int value.</returns>
+        public static int ParseIntegerWithinRangeNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, int? min, int? max)
+        {
+            return ParseIntegerWithinRangeNullable(dict, primaryKey, fallbackKeys, defaultValue, min, max, out _);
         }
 
         /// <summary>
@@ -334,7 +632,23 @@ namespace PEBakery.Helper
         /// <returns>Parsed int value.</returns>
         public static int ParseIntegerNullable(Dictionary<string, string?> dict, string key, int defaultValue, out bool incorrectValue)
         {
-            return ParseIntegerNullable(dict, key, defaultValue, null, null, out incorrectValue);
+            return ParseIntegerWithinRangeNullable(dict, key, defaultValue, null, null, out incorrectValue);
+        }
+
+        /// <summary>
+        /// Parse an int value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed int value.</returns>
+        public static int ParseIntegerNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, out bool incorrectValue)
+        {
+            return ParseIntegerWithinRangeNullable(dict, primaryKey, fallbackKeys, defaultValue, null, null, out incorrectValue);
         }
 
         /// <summary>
@@ -350,31 +664,81 @@ namespace PEBakery.Helper
         /// <param name="max">Allowed maximum integer value.</param>
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseIntegerNullable(Dictionary<string, string?> dict, string key, int defaultValue, int? min, int? max, out bool incorrectValue)
+        public static int ParseIntegerWithinRangeNullable(Dictionary<string, string?> dict, string key, int defaultValue, int? min, int? max, out bool incorrectValue)
         {
-            // Check ContainsKey and null
             incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            {
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt))
+                    {
+                        if (min is int minVal && valInt < minVal)
+                            return minVal;
+                        else if (max is int maxVal && maxVal < valInt)
+                            return maxVal;
+                        else
+                            return valInt;
+                    }
+                }
+            }
 
             incorrectValue = true;
-            if (!NumberHelper.ParseInt32(valStr, out int valInt))
-                return defaultValue;
+            return defaultValue;
+        }
 
-            if (min is int minVal && valInt < minVal)
-                return minVal;
-            if (max is int maxVal && maxVal < valInt)
-                return maxVal;
-
+        /// <summary>
+        /// Parse an int value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="min">Allowed minimal integer value.</param>
+        /// <param name="max">Allowed maximum integer value.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed int value.</returns>
+        public static int ParseIntegerWithinRangeNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, int? min, int? max, out bool incorrectValue)
+        {
             incorrectValue = false;
-            return valInt;
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt))
+                    {
+                        if (min is int minVal && valInt < minVal)
+                            return minVal;
+                        else if (max is int maxVal && maxVal < valInt)
+                            return maxVal;
+                        else
+                            return valInt;
+                    }
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt))
+                    {
+                        if (min is int minVal && valInt < minVal)
+                            return minVal;
+                        else if (max is int maxVal && maxVal < valInt)
+                            return maxVal;
+                        else
+                            return valInt;
+                    }
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
         #endregion
 
-        #region ParseEnum
+        #region ParseStrEnum, ParseIntEnum
         /// <summary>
         /// Parse an Enum value from a DOM of an .ini file.
         /// </summary>
@@ -398,6 +762,22 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
+        /// <param name="primaryKeys">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed Enum value.</returns>
+        public static TEnum ParseStrEnum<TEnum>(Dictionary<string, string> dict, string primaryKeys, IEnumerable<string> fallbackKeys, TEnum defaultValue)
+            where TEnum : struct, Enum
+        {
+            return ParseStrEnum(dict, primaryKeys, fallbackKeys, defaultValue, out _);
+        }
+
+        /// <summary>
+        /// Parse an Enum value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
@@ -406,18 +786,52 @@ namespace PEBakery.Helper
             where TEnum : struct, Enum
         {
             incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            {
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
+                        return defaultValue;
+                }
+            }
 
             incorrectValue = true;
-            if (!Enum.TryParse(valStr, true, out TEnum kind) || !Enum.IsDefined(typeof(TEnum), kind))
-                return defaultValue;
+            return defaultValue;
+        }
 
+        /// <summary>
+        /// Parse an Enum value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed Enum value.</returns>
+        public static TEnum ParseStrEnum<TEnum>(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool incorrectValue)
+            where TEnum : struct, Enum
+        {
             incorrectValue = false;
-            return kind;
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (Enum.TryParse(valStr, true, out TEnum kind) &&!Enum.IsDefined(kind))
+                        return defaultValue;
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
+                        return defaultValue;
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
 
         /// <summary>
@@ -431,9 +845,25 @@ namespace PEBakery.Helper
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <returns>Parsed Enum value.</returns>
         public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string> dict, string key, TEnum defaultValue)
-            where TEnum : Enum
+            where TEnum : struct, Enum
         {
             return ParseIntEnum(dict, key, defaultValue, out _);
+        }
+
+        /// <summary>
+        /// Parse an Enum value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed Enum value.</returns>
+        public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue)
+            where TEnum : struct, Enum
+        {
+            return ParseIntEnum(dict, primaryKey, fallbackKeys, defaultValue, out _);
         }
 
         /// <summary>
@@ -448,28 +878,59 @@ namespace PEBakery.Helper
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
         public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string> dict, string key, TEnum defaultValue, out bool incorrectValue)
-            where TEnum : Enum
+            where TEnum : struct, Enum
         {
             incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            {
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                        return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                }
+            }
 
             incorrectValue = true;
-            if (!NumberHelper.ParseInt32(valStr, out int valInt))
-                return defaultValue;
+            return defaultValue;
+        }
 
-            if (!Enum.IsDefined(typeof(TEnum), valInt))
-                return defaultValue;
-
+        /// <summary>
+        /// Parse an Enum value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed Enum value.</returns>
+        public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool incorrectValue)
+            where TEnum : struct, Enum
+        {
             incorrectValue = false;
-            return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                        return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                        return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
         #endregion
 
-        #region ParseEnumNullable
+        #region ParseStrEnumNullable, ParseIntEnumNullable
         /// <summary>
         /// Parse an Enum value from a DOM of an .ini file.
         /// </summary>
@@ -493,6 +954,22 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed Enum value.</returns>
+        public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey , IEnumerable<string> fallbackKeys, TEnum defaultValue)
+            where TEnum : struct, Enum
+        {
+            return ParseStrEnumNullable(dict, primaryKey, defaultValue, out _);
+        }
+
+        /// <summary>
+        /// Parse an Enum value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
@@ -501,18 +978,52 @@ namespace PEBakery.Helper
             where TEnum : struct, Enum
         {
             incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            {
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
+                        return defaultValue;
+                }
+            }
 
             incorrectValue = true;
-            if (!Enum.TryParse(valStr, true, out TEnum kind) || !Enum.IsDefined(typeof(TEnum), kind))
-                return defaultValue;
+            return defaultValue;
+        }
 
+        /// <summary>
+        /// Parse an Enum value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed Enum value.</returns>
+        public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool incorrectValue)
+            where TEnum : struct, Enum
+        {
             incorrectValue = false;
-            return kind;
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
+                        return defaultValue;
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
+                        return defaultValue;
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
 
         /// <summary>
@@ -538,6 +1049,22 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed Enum value.</returns>
+        public static TEnum ParseIntEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue)
+            where TEnum : Enum
+        {
+            return ParseIntEnumNullable(dict, primaryKey, fallbackKeys, defaultValue, out _);
+        }
+
+        /// <summary>
+        /// Parse an Enum value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
@@ -546,21 +1073,52 @@ namespace PEBakery.Helper
             where TEnum : Enum
         {
             incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
+            {
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                        return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                }
+            }
 
             incorrectValue = true;
-            if (!NumberHelper.ParseInt32(valStr, out int valInt))
-                return defaultValue;
+            return defaultValue;
+        }
 
-            if (!Enum.IsDefined(typeof(TEnum), valInt))
-                return defaultValue;
-
+        /// <summary>
+        /// Parse an Enum value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed Enum value.</returns>
+        public static TEnum ParseIntEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool incorrectValue)
+            where TEnum : Enum
+        {
             incorrectValue = false;
-            return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+            {
+                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                        return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                        return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
         #endregion
 
@@ -578,6 +1136,21 @@ namespace PEBakery.Helper
         public static Color ParseColor(Dictionary<string, string> dict, string key, Color defaultValue)
         {
             return ParseColor(dict, key, defaultValue, out _);
+        }
+
+        /// <summary>
+        /// Parse a color value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed color value.</returns>
+        public static Color ParseColor(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, Color defaultValue)
+        {
+            return ParseColor(dict, primaryKey, fallbackKeys, defaultValue, out _);
         }
 
         /// <summary>
@@ -644,12 +1217,108 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed color value.</returns>
+        public static Color ParseColor(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, Color defaultValue, out bool incorrectValue)
+        {
+            static Color? InternalParseColor(string str)
+            {
+                // Format = R, G, B (in base 10)
+                string[] colorStrs = [.. str.Split(',').Select(x => x.Trim())];
+                if (colorStrs.Length == 3)
+                    return null;
+
+                byte[] c = new byte[3]; // R, G, B
+                for (int i = 0; i < 3; i++)
+                {
+                    string colorStr = colorStrs[i];
+                    if (!byte.TryParse(colorStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out byte valByte))
+                    {
+                        char ch;
+                        switch (i)
+                        {
+                            case 0: // Red
+                                ch = 'R';
+                                break;
+                            case 1: // Green
+                                ch = 'G';
+                                break;
+                            case 2: // Blue
+                                ch = 'B';
+                                break;
+                            default: // Unknown
+                                ch = 'U';
+                                break;
+                        }
+                        Debug.Assert(ch != 'U', "Unknown color parsing index");
+                        break;
+                    }
+                    c[i] = valByte;
+                }
+
+                return Color.FromRgb(c[0], c[1], c[2]);
+            }
+
+            incorrectValue = true;
+            {
+                if (!dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    Color? parsed = InternalParseColor(valStr);
+                    if (parsed.HasValue)
+                    {
+                        incorrectValue = false;
+                        return parsed.Value;
+                    }
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    Color? parsed = InternalParseColor(valStr);
+                    if (parsed.HasValue)
+                    {
+                        incorrectValue = false;
+                        return parsed.Value;
+                    }
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
+        }
+
+        /// <summary>
+        /// Parse a color value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <returns>Parsed color value.</returns>
         public static Color ParseColorNullable(Dictionary<string, string?> dict, string key, Color defaultValue)
         {
             return ParseColorNullable(dict, key, defaultValue, out _);
+        }
+
+        /// <summary>
+        /// Parse a color value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <returns>Parsed color value.</returns>
+        public static Color ParseColorNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, Color defaultValue)
+        {
+            return ParseColorNullable(dict, primaryKey, fallbackKeys, defaultValue, out _);
         }
 
         /// <summary>
@@ -708,6 +1377,87 @@ namespace PEBakery.Helper
 
             incorrectValue = false;
             return Color.FromRgb(c[0], c[1], c[2]);
+        }
+
+        /// <summary>
+        /// Parse a color value from a DOM of an .ini file.
+        /// </summary>
+        /// <param name="dict">
+        /// The DOM of an .ini file.
+        /// Dict Key means ini section, and Dict Value means ini value.
+        /// </param>
+        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
+        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <returns>Parsed color value.</returns>
+        public static Color ParseColorNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, Color defaultValue, out bool incorrectValue)
+        {
+            static Color? InternalParseColor(string str)
+            {
+                // Format = R, G, B (in base 10)
+                string[] colorStrs = [.. str.Split(',').Select(x => x.Trim())];
+                if (colorStrs.Length == 3)
+                    return null;
+
+                byte[] c = new byte[3]; // R, G, B
+                for (int i = 0; i < 3; i++)
+                {
+                    string colorStr = colorStrs[i];
+                    if (!byte.TryParse(colorStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out byte valByte))
+                    {
+                        char ch;
+                        switch (i)
+                        {
+                            case 0: // Red
+                                ch = 'R';
+                                break;
+                            case 1: // Green
+                                ch = 'G';
+                                break;
+                            case 2: // Blue
+                                ch = 'B';
+                                break;
+                            default: // Unknown
+                                ch = 'U';
+                                break;
+                        }
+                        Debug.Assert(ch != 'U', "Unknown color parsing index");
+                        break;
+                    }
+                    c[i] = valByte;
+                }
+
+                return Color.FromRgb(c[0], c[1], c[2]);
+            }
+
+            incorrectValue = true;
+            {
+                if (!dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                {
+                    Color? parsed = InternalParseColor(valStr);
+                    if (parsed.HasValue)
+                    {
+                        incorrectValue = false;
+                        return parsed.Value;
+                    }
+                }
+            }
+
+            foreach (string fallbackKey in fallbackKeys)
+            {
+                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    Color? parsed = InternalParseColor(valStr);
+                    if (parsed.HasValue)
+                    {
+                        incorrectValue = false;
+                        return parsed.Value;
+                    }
+                }
+            }
+
+            incorrectValue = true;
+            return defaultValue;
         }
         #endregion
     }

--- a/PEBakery.Helper/SilentDictParser.cs
+++ b/PEBakery.Helper/SilentDictParser.cs
@@ -1039,7 +1039,7 @@ namespace PEBakery.Helper
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey , IEnumerable<string> fallbackKeys, TEnum defaultValue)
+        public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue)
             where TEnum : struct, Enum
         {
             return ParseStrEnumNullable(dict, primaryKey, fallbackKeys, defaultValue, out _);
@@ -1160,7 +1160,6 @@ namespace PEBakery.Helper
         public static TEnum ParseIntEnumNullable<TEnum>(Dictionary<string, string?> dict, string key, TEnum defaultValue, out bool unparsableValue)
             where TEnum : Enum
         {
-            unparsableValue = false;
             {
                 if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
                 {

--- a/PEBakery.Helper/SilentDictParser.cs
+++ b/PEBakery.Helper/SilentDictParser.cs
@@ -25,7 +25,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Media;

--- a/PEBakery.Helper/SilentDictParser.cs
+++ b/PEBakery.Helper/SilentDictParser.cs
@@ -214,20 +214,32 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed boolean value.</returns>
-        public static bool ParseBoolean(Dictionary<string, string> dict, string primaryKey, bool defaultValue, out bool incorrectValue)
+        public static bool ParseBoolean(Dictionary<string, string> dict, string key, bool defaultValue, out bool unparsableValue)
         {
-            incorrectValue = false;
-            if (dict.TryGetValue(primaryKey, out string? valRawStr) && valRawStr is string valStr)
             {
-                if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
-                    return true;
-                else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
-                    return false;
+                if (dict.TryGetValue(key, out string? fallbackValStr) && fallbackValStr is string valStr)
+                {
+                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unparsableValue = false;
+                        return true;
+                    }
+                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unparsableValue = false;
+                        return false;
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
+                }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -240,33 +252,33 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed boolean value.</returns>
-        public static bool ParseBoolean(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, bool defaultValue, out bool incorrectValue)
+        public static bool ParseBoolean(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, bool defaultValue, out bool unparsableValue)
         {
-            incorrectValue = false;
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
                     if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unparsableValue = false;
                         return true;
+                    }
                     else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unparsableValue = false;
                         return false;
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
                 }
             }
 
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
-                        return true;
-                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
-                        return false;
-                }
-            }
-
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
         #endregion
@@ -311,22 +323,32 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="key">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed boolean value.</returns>
-        public static bool ParseBooleanNullable(Dictionary<string, string?> dict, string key, bool defaultValue, out bool incorrectValue)
+        public static bool ParseBooleanNullable(Dictionary<string, string?> dict, string key, bool defaultValue, out bool unparsableValue)
         {
-            incorrectValue = false;
             {
-                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
                     if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unparsableValue = false;
                         return true;
+                    }
                     else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unparsableValue = false;
                         return false;
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -339,33 +361,33 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini value.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed boolean value.</returns>
-        public static bool ParseBooleanNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, bool defaultValue, out bool incorrectValue)
+        public static bool ParseBooleanNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, bool defaultValue, out bool unparsableValue)
         {
-            incorrectValue = false;
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
-                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                    if (rawValStr.Equals("True", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unparsableValue = false;
                         return true;
-                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                    }
+                    else if (rawValStr.Equals("False", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unparsableValue = false;
                         return false;
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }    
                 }
             }
 
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    if (valStr.Equals("True", StringComparison.OrdinalIgnoreCase))
-                        return true;
-                    else if (valStr.Equals("False", StringComparison.OrdinalIgnoreCase))
-                        return false;
-                }
-            }
-
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
         #endregion
@@ -444,11 +466,11 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseInteger(Dictionary<string, string> dict, string primaryKey, int defaultValue, out bool incorrectValue)
+        public static int ParseInteger(Dictionary<string, string> dict, string primaryKey, int defaultValue, out bool unparsableValue)
         {
-            return ParseIntegerWithinRange(dict, primaryKey, defaultValue, null, null, out incorrectValue);
+            return ParseIntegerWithinRange(dict, primaryKey, defaultValue, null, null, out unparsableValue);
         }
 
         /// <summary>
@@ -460,11 +482,11 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseInteger(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, out bool incorrectValue)
+        public static int ParseInteger(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, out bool unparsableValue)
         {
-            return ParseIntegerWithinRange(dict, primaryKey, fallbackKeys, defaultValue, null, null, out incorrectValue);
+            return ParseIntegerWithinRange(dict, primaryKey, fallbackKeys, defaultValue, null, null, out unparsableValue);
         }
 
         /// <summary>
@@ -474,31 +496,51 @@ namespace PEBakery.Helper
         /// The DOM of an .ini file.
         /// Dict Key means ini section, and Dict Value means ini value.
         /// </param>
-        /// <param name="primaryKey">Name of the ini section.</param>
+        /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="min">Allowed minimal integer value.</param>
         /// <param name="max">Allowed maximum integer value.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseIntegerWithinRange(Dictionary<string, string> dict, string primaryKey, int defaultValue, int? min, int? max, out bool incorrectValue)
+        public static int ParseIntegerWithinRange(Dictionary<string, string> dict, string key, int defaultValue, int? min, int? max, out bool unparsableValue)
         {
-            incorrectValue = false;
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (min is int minVal && defaultValue < minVal)
+                    defaultValue = minVal;
+                if (max is int maxVal && maxVal < defaultValue)
+                    defaultValue = maxVal;
+            }
+
+            {
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
                 {
                     if (NumberHelper.ParseInt32(valStr, out int valInt))
                     {
                         if (min is int minVal && valInt < minVal)
+                        {
+                            unparsableValue = true;
                             return minVal;
+                        }
                         else if (max is int maxVal && maxVal < valInt)
+                        {
+                            unparsableValue = true;
                             return maxVal;
+                        }
                         else
+                        {
+                            unparsableValue = false;
                             return valInt;
+                        }
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
                     }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -513,43 +555,48 @@ namespace PEBakery.Helper
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="min">Allowed minimal integer value.</param>
         /// <param name="max">Allowed maximum integer value.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseIntegerWithinRange(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, int? min, int? max, out bool incorrectValue)
+        public static int ParseIntegerWithinRange(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, int? min, int? max, out bool unparsableValue)
         {
-            incorrectValue = false;
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (min is int minVal && defaultValue < minVal)
+                    defaultValue = minVal;
+                if (max is int maxVal && maxVal < defaultValue)
+                    defaultValue = maxVal;
+            }
+
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
+            {
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
                     if (NumberHelper.ParseInt32(valStr, out int valInt))
                     {
                         if (min is int minVal && valInt < minVal)
+                        {
+                            unparsableValue = true;
                             return minVal;
+                        }
                         else if (max is int maxVal && maxVal < valInt)
+                        {
+                            unparsableValue = true;
                             return maxVal;
+                        }
                         else
+                        {
+                            unparsableValue = false;
                             return valInt;
+                        }
                     }
-                }
-            }
-
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    if (NumberHelper.ParseInt32(valStr, out int valInt))
+                    else
                     {
-                        if (min is int minVal && valInt < minVal)
-                            return minVal;
-                        else if (max is int maxVal && maxVal < valInt)
-                            return maxVal;
-                        else
-                            return valInt;
+                        unparsableValue = true;
+                        return defaultValue;
                     }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
         #endregion
@@ -628,11 +675,11 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseIntegerNullable(Dictionary<string, string?> dict, string key, int defaultValue, out bool incorrectValue)
+        public static int ParseIntegerNullable(Dictionary<string, string?> dict, string key, int defaultValue, out bool unparsableValue)
         {
-            return ParseIntegerWithinRangeNullable(dict, key, defaultValue, null, null, out incorrectValue);
+            return ParseIntegerWithinRangeNullable(dict, key, defaultValue, null, null, out unparsableValue);
         }
 
         /// <summary>
@@ -644,11 +691,11 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseIntegerNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, out bool incorrectValue)
+        public static int ParseIntegerNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, out bool unparsableValue)
         {
-            return ParseIntegerWithinRangeNullable(dict, primaryKey, fallbackKeys, defaultValue, null, null, out incorrectValue);
+            return ParseIntegerWithinRangeNullable(dict, primaryKey, fallbackKeys, defaultValue, null, null, out unparsableValue);
         }
 
         /// <summary>
@@ -662,27 +709,47 @@ namespace PEBakery.Helper
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="min">Allowed minimal integer value.</param>
         /// <param name="max">Allowed maximum integer value.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseIntegerWithinRangeNullable(Dictionary<string, string?> dict, string key, int defaultValue, int? min, int? max, out bool incorrectValue)
+        public static int ParseIntegerWithinRangeNullable(Dictionary<string, string?> dict, string key, int defaultValue, int? min, int? max, out bool unparsableValue)
         {
-            incorrectValue = false;
+            {
+                if (min is int minVal && defaultValue < minVal)
+                    defaultValue = minVal;
+                if (max is int maxVal && maxVal < defaultValue)
+                    defaultValue = maxVal;
+            }
+
             {
                 if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
                 {
                     if (NumberHelper.ParseInt32(valStr, out int valInt))
                     {
                         if (min is int minVal && valInt < minVal)
+                        {
+                            unparsableValue = true;
                             return minVal;
+                        }
                         else if (max is int maxVal && maxVal < valInt)
+                        {
+                            unparsableValue = true;
                             return maxVal;
+                        }
                         else
+                        {
+                            unparsableValue = false;
                             return valInt;
+                        }
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
                     }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -697,43 +764,48 @@ namespace PEBakery.Helper
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
         /// <param name="min">Allowed minimal integer value.</param>
         /// <param name="max">Allowed maximum integer value.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed int value.</returns>
-        public static int ParseIntegerWithinRangeNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, int? min, int? max, out bool incorrectValue)
+        public static int ParseIntegerWithinRangeNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, int defaultValue, int? min, int? max, out bool unparsableValue)
         {
-            incorrectValue = false;
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (min is int minVal && defaultValue < minVal)
+                    defaultValue = minVal;
+                if (max is int maxVal && maxVal < defaultValue)
+                    defaultValue = maxVal;
+            }
+
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
+            {
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
                     if (NumberHelper.ParseInt32(valStr, out int valInt))
                     {
                         if (min is int minVal && valInt < minVal)
+                        {
+                            unparsableValue = true;
                             return minVal;
+                        }
                         else if (max is int maxVal && maxVal < valInt)
+                        {
+                            unparsableValue = true;
                             return maxVal;
+                        }
                         else
+                        {
+                            unparsableValue = false;
                             return valInt;
+                        }
                     }
-                }
-            }
-
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    if (NumberHelper.ParseInt32(valStr, out int valInt))
+                    else
                     {
-                        if (min is int minVal && valInt < minVal)
-                            return minVal;
-                        else if (max is int maxVal && maxVal < valInt)
-                            return maxVal;
-                        else
-                            return valInt;
+                        unparsableValue = true;
+                        return defaultValue;
                     }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
         #endregion
@@ -780,21 +852,26 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseStrEnum<TEnum>(Dictionary<string, string> dict, string key, TEnum defaultValue, out bool incorrectValue)
+        public static TEnum ParseStrEnum<TEnum>(Dictionary<string, string> dict, string key, TEnum defaultValue, out bool unparsableValue)
             where TEnum : struct, Enum
         {
-            incorrectValue = false;
+            if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
             {
-                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
+                if (Enum.TryParse(valStr, true, out TEnum kind) && Enum.IsDefined(kind))
                 {
-                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
-                        return defaultValue;
+                    unparsableValue = false;
+                    return kind;
+                }
+                else
+                {
+                    unparsableValue = true;
+                    return defaultValue;
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -807,30 +884,29 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseStrEnum<TEnum>(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool incorrectValue)
+        public static TEnum ParseStrEnum<TEnum>(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool unparsableValue)
             where TEnum : struct, Enum
         {
-            incorrectValue = false;
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
-                    if (Enum.TryParse(valStr, true, out TEnum kind) &&!Enum.IsDefined(kind))
+                    if (Enum.TryParse(valStr, true, out TEnum kind) && Enum.IsDefined(kind))
+                    {
+                        unparsableValue = false;
+                        return kind;
+                    }
+                    else
+                    {
+                        unparsableValue = true;
                         return defaultValue;
+                    }
                 }
             }
 
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
-                        return defaultValue;
-                }
-            }
-
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -875,21 +951,28 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string> dict, string key, TEnum defaultValue, out bool incorrectValue)
+        public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string> dict, string key, TEnum defaultValue, out bool unparsableValue)
             where TEnum : struct, Enum
         {
-            incorrectValue = false;
             {
                 if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
                 {
                     if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                    {
+                        unparsableValue = false;
                         return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -902,30 +985,29 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool incorrectValue)
+        public static TEnum ParseIntEnum<TEnum>(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool unparsableValue)
             where TEnum : struct, Enum
         {
-            incorrectValue = false;
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
                 {
                     if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                    {
+                        unparsableValue = false;
                         return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
                 }
             }
 
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
-                        return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
-                }
-            }
-
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
         #endregion
@@ -960,7 +1042,7 @@ namespace PEBakery.Helper
         public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey , IEnumerable<string> fallbackKeys, TEnum defaultValue)
             where TEnum : struct, Enum
         {
-            return ParseStrEnumNullable(dict, primaryKey, defaultValue, out _);
+            return ParseStrEnumNullable(dict, primaryKey, fallbackKeys, defaultValue, out _);
         }
 
         /// <summary>
@@ -972,21 +1054,28 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string key, TEnum defaultValue, out bool incorrectValue)
+        public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string key, TEnum defaultValue, out bool unparsableValue)
             where TEnum : struct, Enum
         {
-            incorrectValue = false;
             {
                 if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
                 {
-                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
+                    if (Enum.TryParse(valStr, true, out TEnum kind) && Enum.IsDefined(kind))
+                    {
+                        unparsableValue = false;
+                        return kind;
+                    }
+                    else
+                    {
+                        unparsableValue = true;
                         return defaultValue;
+                    }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -999,30 +1088,29 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool incorrectValue)
+        public static TEnum ParseStrEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool unparsableValue)
             where TEnum : struct, Enum
         {
-            incorrectValue = false;
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
                 {
-                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
+                    if (Enum.TryParse(valStr, true, out TEnum kind) && Enum.IsDefined(kind))
+                    {
+                        unparsableValue = false;
+                        return kind;
+                    }
+                    else
+                    {
+                        unparsableValue = true;
                         return defaultValue;
+                    }
                 }
             }
 
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    if (Enum.TryParse(valStr, true, out TEnum kind) && !Enum.IsDefined(kind))
-                        return defaultValue;
-                }
-            }
-
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -1067,21 +1155,29 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseIntEnumNullable<TEnum>(Dictionary<string, string?> dict, string key, TEnum defaultValue, out bool incorrectValue)
+        public static TEnum ParseIntEnumNullable<TEnum>(Dictionary<string, string?> dict, string key, TEnum defaultValue, out bool unparsableValue)
             where TEnum : Enum
         {
-            incorrectValue = false;
+            unparsableValue = false;
             {
                 if (dict.TryGetValue(key, out string? priValStr) && priValStr is string valStr)
                 {
                     if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                    {
+                        unparsableValue = false;
                         return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -1094,35 +1190,53 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed Enum value.</returns>
-        public static TEnum ParseIntEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool incorrectValue)
+        public static TEnum ParseIntEnumNullable<TEnum>(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, TEnum defaultValue, out bool unparsableValue)
             where TEnum : Enum
         {
-            incorrectValue = false;
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
             {
-                if (dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
                     if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
+                    {
+                        unparsableValue = false;
                         return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
+                    }
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
                 }
             }
 
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    if (NumberHelper.ParseInt32(valStr, out int valInt) && Enum.IsDefined(typeof(TEnum), valInt))
-                        return (TEnum)Enum.ToObject(typeof(TEnum), valInt);
-                }
-            }
-
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
         #endregion
 
         #region ParseColor
+        private static Color? InternalParseColor(string str)
+        {
+            // Format = R, G, B (in base 10)
+            string[] colorStrs = [.. str.Split(',').Select(x => x.Trim())];
+            if (colorStrs.Length != 3)
+                return null;
+
+            byte[] c = new byte[3]; // R, G, B
+            for (int i = 0; i < 3; i++)
+            {
+                string colorStr = colorStrs[i];
+                if (!byte.TryParse(colorStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out byte valByte))
+                    return null;
+                c[i] = valByte;
+            }
+
+            return Color.FromRgb(c[0], c[1], c[2]);
+        }
+
         /// <summary>
         /// Parse a color value from a DOM of an .ini file.
         /// </summary>
@@ -1162,52 +1276,29 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed color value.</returns>
-        public static Color ParseColor(Dictionary<string, string> dict, string key, Color defaultValue, out bool incorrectValue)
+        public static Color ParseColor(Dictionary<string, string> dict, string key, Color defaultValue, out bool unparsableValue)
         {
-            incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            incorrectValue = true;
-            string valStr = dict[key];
-
-            // Format = R, G, B (in base 10)
-            string[] colorStrs = valStr.Split(',').Select(x => x.Trim()).ToArray();
-            if (colorStrs.Length != 3)
-                return defaultValue;
-
-            byte[] c = new byte[3]; // R, G, B
-            for (int i = 0; i < 3; i++)
             {
-                string colorStr = colorStrs[i];
-                if (!byte.TryParse(colorStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out byte valByte))
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
-                    char ch;
-                    switch (i)
+                    Color? parsed = InternalParseColor(valStr);
+                    if (parsed.HasValue)
                     {
-                        case 0: // Red
-                            ch = 'R';
-                            break;
-                        case 1: // Green
-                            ch = 'G';
-                            break;
-                        case 2: // Blue
-                            ch = 'B';
-                            break;
-                        default: // Unknown
-                            ch = 'U';
-                            break;
+                        unparsableValue = false;
+                        return parsed.Value;
                     }
-                    Debug.Assert(ch != 'U', "Unknown color parsing index");
-                    return defaultValue;
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
                 }
-                c[i] = valByte;
             }
 
-            incorrectValue = false;
-            return Color.FromRgb(c[0], c[1], c[2]);
+            unparsableValue = false;
+            return defaultValue;
         }
 
         /// <summary>
@@ -1219,75 +1310,29 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed color value.</returns>
-        public static Color ParseColor(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, Color defaultValue, out bool incorrectValue)
+        public static Color ParseColor(Dictionary<string, string> dict, string primaryKey, IEnumerable<string> fallbackKeys, Color defaultValue, out bool unparsableValue)
         {
-            static Color? InternalParseColor(string str)
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
             {
-                // Format = R, G, B (in base 10)
-                string[] colorStrs = [.. str.Split(',').Select(x => x.Trim())];
-                if (colorStrs.Length == 3)
-                    return null;
-
-                byte[] c = new byte[3]; // R, G, B
-                for (int i = 0; i < 3; i++)
-                {
-                    string colorStr = colorStrs[i];
-                    if (!byte.TryParse(colorStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out byte valByte))
-                    {
-                        char ch;
-                        switch (i)
-                        {
-                            case 0: // Red
-                                ch = 'R';
-                                break;
-                            case 1: // Green
-                                ch = 'G';
-                                break;
-                            case 2: // Blue
-                                ch = 'B';
-                                break;
-                            default: // Unknown
-                                ch = 'U';
-                                break;
-                        }
-                        Debug.Assert(ch != 'U', "Unknown color parsing index");
-                        break;
-                    }
-                    c[i] = valByte;
-                }
-
-                return Color.FromRgb(c[0], c[1], c[2]);
-            }
-
-            incorrectValue = true;
-            {
-                if (!dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
                     Color? parsed = InternalParseColor(valStr);
                     if (parsed.HasValue)
                     {
-                        incorrectValue = false;
+                        unparsableValue = false;
                         return parsed.Value;
                     }
-                }
-            }
-
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    Color? parsed = InternalParseColor(valStr);
-                    if (parsed.HasValue)
+                    else
                     {
-                        incorrectValue = false;
-                        return parsed.Value;
+                        unparsableValue = true;
+                        return defaultValue;
                     }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
 
@@ -1330,53 +1375,29 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="key">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed color value.</returns>
-        public static Color ParseColorNullable(Dictionary<string, string?> dict, string key, Color defaultValue, out bool incorrectValue)
+        public static Color ParseColorNullable(Dictionary<string, string?> dict, string key, Color defaultValue, out bool unparsableValue)
         {
-            incorrectValue = false;
-            if (!dict.ContainsKey(key))
-                return defaultValue;
-
-            if (dict[key] is not string valStr)
-                return defaultValue;
-
-            // Format = R, G, B (in base 10)
-            incorrectValue = true;
-            string[] colorStrs = valStr.Split(',').Select(x => x.Trim()).ToArray();
-            if (colorStrs.Length != 3)
-                return defaultValue;
-
-            byte[] c = new byte[3]; // R, G, B
-            for (int i = 0; i < 3; i++)
             {
-                string colorStr = colorStrs[i];
-                if (!byte.TryParse(colorStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out byte valByte))
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
-                    char ch;
-                    switch (i)
+                    Color? parsed = InternalParseColor(valStr);
+                    if (parsed.HasValue)
                     {
-                        case 0: // Red
-                            ch = 'R';
-                            break;
-                        case 1: // Green
-                            ch = 'G';
-                            break;
-                        case 2: // Blue
-                            ch = 'B';
-                            break;
-                        default: // Unknown
-                            ch = 'U';
-                            break;
+                        unparsableValue = false;
+                        return parsed.Value;
                     }
-                    Debug.Assert(ch != 'U', "Unknown color parsing index");
-                    return defaultValue;
+                    else
+                    {
+                        unparsableValue = true;
+                        return defaultValue;
+                    }
                 }
-                c[i] = valByte;
             }
 
-            incorrectValue = false;
-            return Color.FromRgb(c[0], c[1], c[2]);
+            unparsableValue = false;
+            return defaultValue;
         }
 
         /// <summary>
@@ -1388,75 +1409,29 @@ namespace PEBakery.Helper
         /// </param>
         /// <param name="primaryKey">Name of the ini section.</param>
         /// <param name="defaultValue">Default value to use when the dict value is empty.</param>
-        /// <param name="incorrectValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
+        /// <param name="unparsableValue">Set to true when the value is not correct. Will not be set to true on empty value.</param>
         /// <returns>Parsed color value.</returns>
-        public static Color ParseColorNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, Color defaultValue, out bool incorrectValue)
+        public static Color ParseColorNullable(Dictionary<string, string?> dict, string primaryKey, IEnumerable<string> fallbackKeys, Color defaultValue, out bool unparsableValue)
         {
-            static Color? InternalParseColor(string str)
+            foreach (string key in Enumerable.Empty<string>().Append(primaryKey).Concat(fallbackKeys))
             {
-                // Format = R, G, B (in base 10)
-                string[] colorStrs = [.. str.Split(',').Select(x => x.Trim())];
-                if (colorStrs.Length == 3)
-                    return null;
-
-                byte[] c = new byte[3]; // R, G, B
-                for (int i = 0; i < 3; i++)
-                {
-                    string colorStr = colorStrs[i];
-                    if (!byte.TryParse(colorStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out byte valByte))
-                    {
-                        char ch;
-                        switch (i)
-                        {
-                            case 0: // Red
-                                ch = 'R';
-                                break;
-                            case 1: // Green
-                                ch = 'G';
-                                break;
-                            case 2: // Blue
-                                ch = 'B';
-                                break;
-                            default: // Unknown
-                                ch = 'U';
-                                break;
-                        }
-                        Debug.Assert(ch != 'U', "Unknown color parsing index");
-                        break;
-                    }
-                    c[i] = valByte;
-                }
-
-                return Color.FromRgb(c[0], c[1], c[2]);
-            }
-
-            incorrectValue = true;
-            {
-                if (!dict.TryGetValue(primaryKey, out string? priValStr) && priValStr is string valStr)
+                if (dict.TryGetValue(key, out string? rawValStr) && rawValStr is string valStr)
                 {
                     Color? parsed = InternalParseColor(valStr);
                     if (parsed.HasValue)
                     {
-                        incorrectValue = false;
+                        unparsableValue = false;
                         return parsed.Value;
                     }
-                }
-            }
-
-            foreach (string fallbackKey in fallbackKeys)
-            {
-                if (dict.TryGetValue(fallbackKey, out string? fallbackValStr) && fallbackValStr is string valStr)
-                {
-                    Color? parsed = InternalParseColor(valStr);
-                    if (parsed.HasValue)
+                    else
                     {
-                        incorrectValue = false;
-                        return parsed.Value;
+                        unparsableValue = true;
+                        return defaultValue;
                     }
                 }
             }
 
-            incorrectValue = true;
+            unparsableValue = false;
             return defaultValue;
         }
         #endregion

--- a/PEBakery.Ini/IniReadWriter.cs
+++ b/PEBakery.Ini/IniReadWriter.cs
@@ -139,7 +139,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string? ReadKey(string filePath, string section, string key)
         {
-            IniKey[] iniKeys = InternalReadKeys(filePath, new IniKey[] { new IniKey(section, key) });
+            IniKey[] iniKeys = InternalReadKeys(filePath, [new IniKey(section, key)]);
             return iniKeys[0].Value;
         }
 
@@ -152,7 +152,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string? ReadKey(string filePath, IniKey iniKey)
         {
-            IniKey[] iniKeys = InternalReadKeys(filePath, new IniKey[] { iniKey });
+            IniKey[] iniKeys = InternalReadKeys(filePath, [iniKey]);
             return iniKeys[0].Value;
         }
 
@@ -164,7 +164,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IniKey[] ReadKeys(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalReadKeys(filePath, iniKeys.ToArray());
+            return InternalReadKeys(filePath, [.. iniKeys]);
         }
 
         /// <summary>
@@ -278,7 +278,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteKey(string filePath, string section, string key, string value)
         {
-            return InternalWriteKeys(filePath, new List<IniKey> { new IniKey(section, key, value) });
+            return InternalWriteKeys(filePath, [new IniKey(section, key, value)]);
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteKey(string filePath, IniKey iniKey)
         {
-            return InternalWriteKeys(filePath, new List<IniKey> { iniKey });
+            return InternalWriteKeys(filePath, [iniKey]);
         }
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteKeys(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalWriteKeys(filePath, iniKeys.ToList());
+            return InternalWriteKeys(filePath, [.. iniKeys]);
         }
 
         private static bool InternalWriteKeys(string filePath, List<IniKey> inputKeys)
@@ -318,16 +318,13 @@ namespace PEBakery.Ini
                 if (0 < inputKeys.Count)
                 {
                     // inputKeys are modified in the loop. Call ToArray() to clone inputKeys.
-                    string[] unprocessedSections = inputKeys
+                    string[] unprocessedSections = [.. inputKeys
                         .Select(x => x.Section)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
+                        .Distinct(StringComparer.OrdinalIgnoreCase)];
                     foreach (string section in unprocessedSections)
                     {
                         // inputKeys are modified in the loop. Call ToArray() to clone inputKeys.
-                        IniKey[] secKeys = inputKeys
-                            .Where(x => x.Section.Equals(section))
-                            .ToArray();
+                        IniKey[] secKeys = [.. inputKeys.Where(x => x.Section.Equals(section))];
 
                         if ((lastLine == null || lastLine.Length != 0) && (!firstSection || firstEmptyLine))
                             w.WriteLine();
@@ -375,9 +372,7 @@ namespace PEBakery.Ini
                     void FinalizeSection()
                     {
                         Debug.Assert(currentSection != null);
-                        List<IniKey> secKeys = inputKeys
-                            .Where(x => x.Section.Equals(currentSection, StringComparison.OrdinalIgnoreCase))
-                            .ToList();
+                        List<IniKey> secKeys = [.. inputKeys.Where(x => x.Section.Equals(currentSection, StringComparison.OrdinalIgnoreCase))];
                         Debug.Assert(0 < secKeys.Count);
 
                         // Remove tailing empty lines 
@@ -537,7 +532,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteCompactKey(string filePath, string section, string key, string value)
         {
-            return InternalWriteCompactKeys(filePath, new List<IniKey> { new IniKey(section, key, value) });
+            return InternalWriteCompactKeys(filePath, [new IniKey(section, key, value)]);
         }
 
         /// <summary>
@@ -549,7 +544,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteKeyCompact(string filePath, IniKey iniKey)
         {
-            return InternalWriteCompactKeys(filePath, new List<IniKey> { iniKey });
+            return InternalWriteCompactKeys(filePath, [iniKey]);
         }
 
         /// <summary>
@@ -561,7 +556,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteCompactKeys(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalWriteCompactKeys(filePath, iniKeys.ToList());
+            return InternalWriteCompactKeys(filePath, [.. iniKeys]);
         }
 
         /// <summary>
@@ -583,16 +578,13 @@ namespace PEBakery.Ini
                 if (0 < inputKeys.Count)
                 {
                     // inputKeys are modified in the loop. Call ToArray() to clone inputKeys.
-                    string[] unprocessedSections = inputKeys
+                    string[] unprocessedSections = [.. inputKeys
                         .Select(x => x.Section)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
+                        .Distinct(StringComparer.OrdinalIgnoreCase)];
                     foreach (string section in unprocessedSections)
                     {
                         // inputKeys are modified in the loop. Call ToArray() to clone inputKeys.
-                        IniKey[] secKeys = inputKeys
-                            .Where(x => x.Section.Equals(section))
-                            .ToArray();
+                        IniKey[] secKeys = [.. inputKeys.Where(x => x.Section.Equals(section))];
 
                         if ((lastLine == null || lastLine.Length != 0) && (!firstSection || firstEmptyLine))
                             w.WriteLine();
@@ -639,9 +631,7 @@ namespace PEBakery.Ini
                     void FinalizeSection()
                     {
                         Debug.Assert(currentSection != null);
-                        List<IniKey> secKeys = inputKeys
-                            .Where(x => x.Section.Equals(currentSection, StringComparison.OrdinalIgnoreCase))
-                            .ToList();
+                        List<IniKey> secKeys = [.. inputKeys.Where(x => x.Section.Equals(currentSection, StringComparison.OrdinalIgnoreCase))];
                         Debug.Assert(0 < secKeys.Count);
 
                         // Remove tailing empty lines 
@@ -809,7 +799,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteRawLine(string filePath, string section, string rawLine)
         {
-            return InternalWriteRawLine(filePath, new List<IniKey> { new IniKey(section, rawLine) }, true);
+            return InternalWriteRawLine(filePath, [new IniKey(section, rawLine)], true);
         }
 
         /// <summary>
@@ -826,7 +816,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteRawLine(string filePath, string section, string rawLine, bool append)
         {
-            return InternalWriteRawLine(filePath, new List<IniKey> { new IniKey(section, rawLine) }, append);
+            return InternalWriteRawLine(filePath, [new IniKey(section, rawLine)], append);
         }
 
         /// <summary>
@@ -838,7 +828,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteRawLine(string filePath, IniKey iniKey)
         {
-            return InternalWriteRawLine(filePath, new List<IniKey> { iniKey }, true);
+            return InternalWriteRawLine(filePath, [iniKey], true);
         }
 
         /// <summary>
@@ -854,7 +844,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteRawLine(string filePath, IniKey iniKey, bool append)
         {
-            return InternalWriteRawLine(filePath, new List<IniKey> { iniKey }, append);
+            return InternalWriteRawLine(filePath, [iniKey], append);
         }
 
         /// <summary>
@@ -866,7 +856,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteRawLines(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalWriteRawLine(filePath, iniKeys.ToList(), true);
+            return InternalWriteRawLine(filePath, [.. iniKeys], true);
         }
 
         /// <summary>
@@ -882,7 +872,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool WriteRawLines(string filePath, IEnumerable<IniKey> iniKeys, bool append)
         {
-            return InternalWriteRawLine(filePath, iniKeys.ToList(), append);
+            return InternalWriteRawLine(filePath, [.. iniKeys], append);
         }
 
         /// <summary>
@@ -1148,7 +1138,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool RenameKey(string filePath, string section, string oldKey, string newKey)
         {
-            return InternalRenameKeys(filePath, new IniKey[] { new IniKey(section, oldKey, newKey) })[0];
+            return InternalRenameKeys(filePath, [new IniKey(section, oldKey, newKey)])[0];
         }
 
         /// <summary>
@@ -1160,7 +1150,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool RenameKey(string filePath, IniKey iniKey)
         {
-            return InternalRenameKeys(filePath, new IniKey[] { iniKey })[0];
+            return InternalRenameKeys(filePath, [iniKey])[0];
         }
 
         /// <summary>
@@ -1172,7 +1162,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool[] RenameKeys(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalRenameKeys(filePath, iniKeys.ToArray());
+            return InternalRenameKeys(filePath, [.. iniKeys]);
         }
 
         /// <summary>
@@ -1299,7 +1289,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool DeleteKey(string filePath, string section, string key)
         {
-            return InternalDeleteKeys(filePath, new IniKey[] { new IniKey(section, key) })[0];
+            return InternalDeleteKeys(filePath, [new IniKey(section, key)])[0];
         }
 
         /// <summary>
@@ -1311,7 +1301,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool DeleteKey(string filePath, IniKey iniKey)
         {
-            return InternalDeleteKeys(filePath, new IniKey[] { iniKey })[0];
+            return InternalDeleteKeys(filePath, [iniKey])[0];
         }
 
         /// <summary>
@@ -1325,7 +1315,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool[] DeleteKeys(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalDeleteKeys(filePath, iniKeys.ToArray());
+            return InternalDeleteKeys(filePath, [.. iniKeys]);
         }
 
         /// <summary>
@@ -1451,7 +1441,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool DeleteCompactKey(string filePath, string section, string key)
         {
-            return InternalDeleteCompactKeys(filePath, new IniKey[] { new IniKey(section, key) })[0];
+            return InternalDeleteCompactKeys(filePath, [new IniKey(section, key)])[0];
         }
 
         /// <summary>
@@ -1463,7 +1453,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool DeleteCompactKey(string filePath, IniKey iniKey)
         {
-            return InternalDeleteCompactKeys(filePath, new IniKey[] { iniKey })[0];
+            return InternalDeleteCompactKeys(filePath, [iniKey])[0];
         }
 
         /// <summary>
@@ -1474,7 +1464,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool[] DeleteCompactKeys(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalDeleteCompactKeys(filePath, iniKeys.ToArray());
+            return InternalDeleteCompactKeys(filePath, [.. iniKeys]);
         }
 
         /// <summary>
@@ -1603,7 +1593,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IniKey[]? ReadSection(string filePath, string section)
         {
-            return InternalReadSection(filePath, new string[] { section }).Select(x => x.Value).First();
+            return InternalReadSection(filePath, [section]).Select(x => x.Value).First();
         }
 
         /// <summary>
@@ -1618,7 +1608,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IniKey[]? ReadSection(string filePath, IniKey iniKey)
         {
-            return InternalReadSection(filePath, new string[] { iniKey.Section }).Select(x => x.Value).First();
+            return InternalReadSection(filePath, [iniKey.Section]).Select(x => x.Value).First();
         }
 
         /// <summary>
@@ -1635,7 +1625,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Dictionary<string, IniKey[]?> ReadSections(string filePath, IEnumerable<string> sections)
         {
-            return InternalReadSection(filePath, sections.ToArray());
+            return InternalReadSection(filePath, [.. sections]);
         }
 
         /// <summary>
@@ -1652,7 +1642,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Dictionary<string, IniKey[]?> ReadSections(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalReadSection(filePath, iniKeys.Select(x => x.Section).ToArray());
+            return InternalReadSection(filePath, [.. iniKeys.Select(x => x.Section)]);
         }
 
         /// <summary>
@@ -1754,7 +1744,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool AddSection(string filePath, string section)
         {
-            return InternalAddSection(filePath, new List<string> { section });
+            return InternalAddSection(filePath, [section]);
         }
 
         /// <summary>
@@ -1766,7 +1756,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool AddSection(string filePath, IniKey iniKey)
         {
-            return InternalAddSection(filePath, new List<string> { iniKey.Section });
+            return InternalAddSection(filePath, [iniKey.Section]);
         }
 
         /// <summary>
@@ -1778,7 +1768,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool AddSections(string filePath, IEnumerable<string> sections)
         {
-            return InternalAddSection(filePath, sections.ToList());
+            return InternalAddSection(filePath, [.. sections]);
         }
 
         /// <summary>
@@ -1790,7 +1780,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool AddSections(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalAddSection(filePath, iniKeys.Select(x => x.Section).ToList());
+            return InternalAddSection(filePath, [.. iniKeys.Select(x => x.Section)]);
         }
 
         private static bool InternalAddSection(string filePath, List<string> sections)
@@ -2054,7 +2044,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool RenameSection(string filePath, string srcSection, string destSection)
         {
-            return InternalRenameSection(filePath, new IniKey[] { new IniKey(srcSection, destSection) })[0];
+            return InternalRenameSection(filePath, [new IniKey(srcSection, destSection)])[0];
         }
 
         /// <summary>
@@ -2069,7 +2059,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool RenameSection(string filePath, IniKey iniKey)
         {
-            return InternalRenameSection(filePath, new IniKey[] { iniKey })[0];
+            return InternalRenameSection(filePath, [iniKey])[0];
         }
 
         /// <summary>
@@ -2084,7 +2074,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool[] RenameSections(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalRenameSection(filePath, iniKeys.ToArray());
+            return InternalRenameSection(filePath, [.. iniKeys]);
         }
 
         /// <summary>
@@ -2180,7 +2170,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool DeleteSection(string filePath, string section)
         {
-            return InternalDeleteSection(filePath, new List<string> { section })[0];
+            return InternalDeleteSection(filePath, [section])[0];
         }
 
         /// <summary>
@@ -2192,7 +2182,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool DeleteSection(string filePath, IniKey iniKey)
         {
-            return InternalDeleteSection(filePath, new List<string> { iniKey.Section })[0];
+            return InternalDeleteSection(filePath, [iniKey.Section])[0];
         }
 
         /// <summary>
@@ -2203,7 +2193,7 @@ namespace PEBakery.Ini
         /// <returns>An array of return value for each IniKey. Returns true if the operation of an iniKey was successful.</returns>
         public static bool[] DeleteSections(string filePath, IEnumerable<string> sections)
         {
-            return InternalDeleteSection(filePath, sections.ToList());
+            return InternalDeleteSection(filePath, [.. sections]);
         }
 
         /// <summary>
@@ -2214,7 +2204,7 @@ namespace PEBakery.Ini
         /// <returns>An array of return value for each IniKey. Returns true if the operation of an iniKey was successful.</returns>
         public static bool[] DeleteSections(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalDeleteSection(filePath, iniKeys.Select(x => x.Section).ToList());
+            return InternalDeleteSection(filePath, [.. iniKeys.Select(x => x.Section)]);
         }
 
         /// <summary>
@@ -2303,7 +2293,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static List<string> ReadRawSection(string filePath, string section)
         {
-            return InternalReadRawSection(filePath, new List<string> { section }, false).Select(x => x.Value).First();
+            return InternalReadRawSection(filePath, [section], false).Select(x => x.Value).First();
         }
 
         /// <summary>
@@ -2316,7 +2306,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static List<string> ReadRawSection(string filePath, string section, bool includeEmptyLines)
         {
-            return InternalReadRawSection(filePath, new List<string> { section }, includeEmptyLines).Select(x => x.Value).First();
+            return InternalReadRawSection(filePath, [section], includeEmptyLines).Select(x => x.Value).First();
         }
 
         /// <summary>
@@ -2328,7 +2318,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static List<string> ReadRawSection(string filePath, IniKey iniKey)
         {
-            return InternalReadRawSection(filePath, new List<string> { iniKey.Section }, false).Select(x => x.Value).First();
+            return InternalReadRawSection(filePath, [iniKey.Section], false).Select(x => x.Value).First();
         }
 
         /// <summary>
@@ -2341,7 +2331,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static List<string> ReadRawSection(string filePath, IniKey iniKey, bool includeEmptyLines)
         {
-            return InternalReadRawSection(filePath, new List<string> { iniKey.Section }, includeEmptyLines).Select(x => x.Value).First();
+            return InternalReadRawSection(filePath, [iniKey.Section], includeEmptyLines).Select(x => x.Value).First();
         }
 
         /// <summary>
@@ -2354,7 +2344,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Dictionary<string, List<string>> ReadRawSections(string filePath, IEnumerable<string> sections)
         {
-            return InternalReadRawSection(filePath, sections.ToList(), false);
+            return InternalReadRawSection(filePath, [.. sections], false);
         }
 
         /// <summary>
@@ -2367,7 +2357,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Dictionary<string, List<string>> ReadRawSections(string filePath, IEnumerable<string> sections, bool includeEmptyLines)
         {
-            return InternalReadRawSection(filePath, sections.ToList(), includeEmptyLines);
+            return InternalReadRawSection(filePath, [.. sections], includeEmptyLines);
         }
 
         /// <summary>
@@ -2379,7 +2369,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Dictionary<string, List<string>> ReadRawSections(string filePath, IEnumerable<IniKey> iniKeys)
         {
-            return InternalReadRawSection(filePath, iniKeys.Select(x => x.Section).ToList(), false);
+            return InternalReadRawSection(filePath, [.. iniKeys.Select(x => x.Section)], false);
         }
 
         /// <summary>
@@ -2392,7 +2382,7 @@ namespace PEBakery.Ini
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Dictionary<string, List<string>> ReadRawSections(string filePath, IEnumerable<IniKey> iniKeys, bool includeEmptyLines)
         {
-            return InternalReadRawSection(filePath, iniKeys.Select(x => x.Section).ToList(), includeEmptyLines);
+            return InternalReadRawSection(filePath, [.. iniKeys.Select(x => x.Section)], includeEmptyLines);
         }
 
         /// <summary>
@@ -2465,7 +2455,7 @@ namespace PEBakery.Ini
                 string section = kvSec.Key;
                 Dictionary<string, string> kvPairs = kvSec.Value;
 
-                List<IniKey> keys = new List<IniKey>();
+                List<IniKey> keys = [];
 
                 // kvKey => Key:Key Value:Value
                 foreach (var kvKey in kvPairs)
@@ -2488,7 +2478,7 @@ namespace PEBakery.Ini
                 string section = kvSec.Key;
                 Dictionary<string, string> kvPairs = kvSec.Value;
 
-                List<IniKey> keys = new List<IniKey>();
+                List<IniKey> keys = [];
 
                 // kvKey => Key:Key Value:Value
                 foreach (var kvKey in kvPairs)
@@ -2503,10 +2493,10 @@ namespace PEBakery.Ini
         public static bool Merge(string srcFile1, string srcFile2, string destFile)
         {
             IniFile[] srcIniFiles =
-            {
+            [
                 new IniFile(srcFile1),
                 new IniFile(srcFile2),
-            };
+            ];
 
             bool result = true;
             foreach (IniFile srcIniFile in srcIniFiles)
@@ -2514,7 +2504,7 @@ namespace PEBakery.Ini
                 // kvSec => Key: Section Value:<Key-Value>
                 foreach (var kvSec in srcIniFile.Sections)
                 {
-                    List<IniKey> keys = new List<IniKey>();
+                    List<IniKey> keys = [];
 
                     // kvKey => Key:Key Value:Value
                     foreach (var kvKey in kvSec.Value)
@@ -2582,7 +2572,7 @@ namespace PEBakery.Ini
         /// <returns>List of section names.</returns>
         public static List<string> ReadSectionNames(string filePath)
         {
-            List<string> sections = new List<string>();
+            List<string> sections = [];
 
             Encoding encoding = EncodingHelper.DetectEncoding(filePath);
             using (StreamReader r = new StreamReader(filePath, encoding, true))
@@ -2656,7 +2646,7 @@ namespace PEBakery.Ini
         /// <returns>A list of section content text lines. Returns null if section was not found.</returns>
         public static List<string>? ParseIniSection(string filePath, string section)
         {
-            List<string> lines = new List<string>();
+            List<string> lines = [];
 
             Encoding encoding = SmarterDetectEncoding(filePath, section);
             using (StreamReader r = new StreamReader(filePath, encoding, false))
@@ -2709,7 +2699,7 @@ namespace PEBakery.Ini
         /// <returns>A list of section content text lines. Returns null if section was not found.</returns>
         public static List<string>? ParseRawSection(string filePath, string section)
         {
-            List<string> lines = new List<string>();
+            List<string> lines = [];
 
             Encoding encoding = SmarterDetectEncoding(filePath, section);
             using (StreamReader r = new StreamReader(filePath, encoding, false))
@@ -2769,18 +2759,18 @@ namespace PEBakery.Ini
         /// <returns>An array of Dictionary of keys and values.</returns>
         public static List<string>[] ParseIniSections(string filePath, IEnumerable<string> sections)
         {
-            string[] sectionNames = sections.Distinct().ToArray(); // Remove duplicate
+            string[] sectionNames = [.. sections.Distinct()]; // Remove duplicate
 
             List<string>[] lines = new List<string>[sectionNames.Length];
             for (int i = 0; i < sectionNames.Length; i++)
-                lines[i] = new List<string>();
+                lines[i] = [];
 
             Encoding encoding = SmarterDetectEncoding(filePath, sectionNames);
             using (StreamReader r = new StreamReader(filePath, encoding, true))
             {
                 string? rawLine;
                 int currentSection = -1; // -1 == empty, 0, 1, ... == index value of sections array
-                List<int> processedSectionIdxs = new List<int>();
+                List<int> processedSectionIdxs = [];
 
                 while ((rawLine = r.ReadLine()) != null)
                 { // Read text line by line
@@ -2887,8 +2877,7 @@ namespace PEBakery.Ini
         /// <param name="section">Section to find.</param>
         public static void FastForwardTextReader(TextReader tr, string section)
         {
-            if (section == null)
-                throw new ArgumentNullException(nameof(section));
+            ArgumentNullException.ThrowIfNull(section);
 
             // Read base64 block directly from file
             string? rawLine;
@@ -3129,8 +3118,8 @@ namespace PEBakery.Ini
         /// </returns>
         public static (List<string> Keys, List<string> Values) GetKeyValueFromLines(IEnumerable<string> rawLines)
         {
-            List<string> keys = new List<string>();
-            List<string> values = new List<string>();
+            List<string> keys = [];
+            List<string> values = [];
             foreach (string rawLine in rawLines)
             {
                 if (IsLineComment(rawLine))

--- a/PEBakery/WPF/SettingWindow.xaml
+++ b/PEBakery/WPF/SettingWindow.xaml
@@ -43,7 +43,7 @@
         Loaded="Window_Loaded"
         WindowStartupLocation="CenterOwner"
         Title="PEBakery Settings"
-        Width="600" Height="560"
+        Width="700" Height="600"
         Icon="/Resources/Donut.ico"
         d:DataContext="{d:DesignInstance Type=local:SettingViewModel}">
     <Window.CommandBindings>
@@ -1027,8 +1027,13 @@
                                   IsChecked="{Binding CompatEnableEnvironmentVariables}" />
                         <CheckBox Margin="0, 0, 0, 3"
                                   VerticalContentAlignment="Center"
-                                  Content="Disable extended section parameters (e.g. #a, #r)"
-                                  IsChecked="{Binding CompatDisableExtendedSectionParams}" />
+                                  Content="Enable legacy sharp-styled section parameters (e.g. #1, #2, ...)"
+                                  ToolTip="Sharp-styled section parameter is deprecated in favor of new percent style section parameters (%^..%)"
+                                  IsChecked="{Binding CompatEnableAllLegacySectionParams}" />
+                        <CheckBox Margin="0, 0, 0, 3"
+                                  VerticalContentAlignment="Center"
+                                  Content="Disable legacy sharp-styled extended section parameters (e.g. #a, #r, ...)"
+                                  IsChecked="{Binding CompatDisableLegacyExtendedSectionParams}" />
                     </StackPanel>
                 </StackPanel>
             </TabItem>

--- a/PEBakery/WPF/SettingWindow.xaml.cs
+++ b/PEBakery/WPF/SettingWindow.xaml.cs
@@ -1033,13 +1033,25 @@ namespace PEBakery.WPF
             }
         }
 
-        private bool _compatDisableExtendedSectionParams;
-        public bool CompatDisableExtendedSectionParams
+        private bool _compatEnableAllLegacySectionParams;
+        public bool CompatEnableAllLegacySectionParams
         {
-            get => _compatDisableExtendedSectionParams;
+            get => _compatEnableAllLegacySectionParams;
             set
             {
-                _compatDisableExtendedSectionParams = value;
+                _compatEnableAllLegacySectionParams = value;
+                GetCompatToggleNextState();
+                OnPropertyUpdate();
+            }
+        }
+
+        private bool _compatDisableLegacyExtendedSectionParams;
+        public bool CompatDisableLegacyExtendedSectionParams
+        {
+            get => _compatDisableLegacyExtendedSectionParams;
+            set
+            {
+                _compatDisableLegacyExtendedSectionParams = value;
                 GetCompatToggleNextState();
                 OnPropertyUpdate();
             }
@@ -1230,7 +1242,8 @@ namespace PEBakery.WPF
             CompatOverridableFixedVariables = src.OverridableFixedVariables;
             CompatOverridableLoopCounter = src.OverridableLoopCounter;
             CompatEnableEnvironmentVariables = src.EnableEnvironmentVariables;
-            CompatDisableExtendedSectionParams = src.DisableExtendedSectionParams;
+            CompatEnableAllLegacySectionParams = src.EnableAllLegacySectionParams;
+            CompatDisableLegacyExtendedSectionParams = src.DisableLegacyExtendedSectionParams;
         }
 
         public void SaveCompatOptionTo(CompatOption dest)
@@ -1253,7 +1266,8 @@ namespace PEBakery.WPF
             dest.OverridableFixedVariables = CompatOverridableFixedVariables;
             dest.OverridableLoopCounter = CompatOverridableLoopCounter;
             dest.EnableEnvironmentVariables = CompatEnableEnvironmentVariables;
-            dest.DisableExtendedSectionParams = CompatDisableExtendedSectionParams;
+            dest.EnableAllLegacySectionParams = CompatEnableAllLegacySectionParams;
+            dest.DisableLegacyExtendedSectionParams = CompatDisableLegacyExtendedSectionParams;
         }
         #endregion
 
@@ -1286,7 +1300,8 @@ namespace PEBakery.WPF
             currentState &= CompatOverridableFixedVariables;
             currentState &= CompatOverridableLoopCounter;
             currentState &= CompatEnableEnvironmentVariables;
-            currentState &= CompatDisableExtendedSectionParams;
+            currentState &= CompatEnableAllLegacySectionParams;
+            currentState &= CompatDisableLegacyExtendedSectionParams;
 
             ToggleNextState = !currentState;
         }
@@ -1314,7 +1329,8 @@ namespace PEBakery.WPF
             CompatOverridableFixedVariables = nextState;
             CompatOverridableLoopCounter = nextState;
             CompatEnableEnvironmentVariables = nextState;
-            CompatDisableExtendedSectionParams = nextState;
+            CompatEnableAllLegacySectionParams = nextState;
+            CompatDisableLegacyExtendedSectionParams = nextState;
         }
         #endregion
 
@@ -1547,16 +1563,16 @@ namespace PEBakery.WPF
 
                 if (srcSetup.PathSettingEnabled)
                 { // PathSetting is enabled
-                    string sourceDir = string.Join(",", srcSetup.SourceDirs.Select(x => StringEscaper.DoubleQuote(x)));
+                    string sourceDir = string.Join(",", srcSetup.SourceDirs.Select(StringEscaper.DoubleQuote));
                     string targetDir = srcSetup.TargetDir;
                     string isoFile = srcSetup.IsoFile;
 
-                    IniReadWriter.WriteKeys(p.MainScript.RealPath, new IniKey[]
-                    {
+                    IniReadWriter.WriteKeys(p.MainScript.RealPath,
+                    [
                         new IniKey(ScriptSection.Names.Main, Script.Const.SourceDir, sourceDir),
                         new IniKey(ScriptSection.Names.Main, Script.Const.TargetDir, targetDir),
                         new IniKey(ScriptSection.Names.Main, Script.Const.IsoFile, isoFile),
-                    });
+                    ]);
 
                     p.Variables.SetValue(VarsType.Fixed, Script.Const.SourceDir, sourceDir);
                     p.Variables.SetValue(VarsType.Fixed, Script.Const.TargetDir, targetDir);
@@ -1568,12 +1584,12 @@ namespace PEBakery.WPF
                 }
                 else
                 { // PathSetting is disabled
-                    IniReadWriter.DeleteKeys(p.MainScript.RealPath, new IniKey[]
-                    {
+                    IniReadWriter.DeleteKeys(p.MainScript.RealPath,
+                    [
                         new IniKey(ScriptSection.Names.Main, Script.Const.SourceDir),
                         new IniKey(ScriptSection.Names.Main, Script.Const.TargetDir),
                         new IniKey(ScriptSection.Names.Main, Script.Const.IsoFile),
-                    });
+                    ]);
 
                     p.Variables.DeleteKey(VarsType.Fixed, Script.Const.SourceDir);
                     p.Variables.DeleteKey(VarsType.Fixed, Script.Const.TargetDir);


### PR DESCRIPTION
## Summary

Introduces percent-style section parameters (`%^SIPARAM_n%`, `%^SOPARAM_n%`, `%^RET%`, `%^LOOP_IDX%`) as the new canonical notation, replacing the legacy `#n` sharp-style parameters.

## Changes

- **Engine**: Wired percent-style section parameters through the engine execution pipeline
- **Variables**: `SetVariable()` routes `%^SIPARAM_n%` keys via `SetPercentSectionInParam`; `#n` keys only route to `SetLegacySectionInParam` when `CompatEnableAllLegacySectionParams` is enabled
- **StringEscaper**: `ExpandSectionParams()` always expands percent-style params; expands legacy `#n` only if `CompatEnableAllLegacySectionParams` is set
- **Compat flag**: `EngineState.CompatEnableAllLegacySectionParams` — when `false` (new default), `#n`-style params are not expanded
- **SilentDictParser**: Added key fallback functionality (two commits)
- **Tests**: Updated existing legacy `#n` tests to set `CompatEnableAllLegacySectionParams = true`; added comprehensive tests for all new percent-style parameters (`%^SIPARAM_n%`, `%^SIPARAM_COUNT%`, `%^SOPARAM_n%`, `%^SOPARAM_COUNT%`, `%^RET%`, `%^LOOP_IDX%`)

## Key New Parameters

| Parameter | Description |
|-----------|-------------|
| `%^SIPARAM_n%` | n-th script input parameter |
| `%^SIPARAM_COUNT%` | Number of input parameters |
| `%^SOPARAM_n%` | n-th script output parameter |
| `%^SOPARAM_COUNT%` | Number of output parameters |
| `%^RET%` | Return value |
| `%^LOOP_IDX%` | Loop counter index |

## Compatibility

Legacy `#n` notation remains supported via the `CompatEnableAllLegacySectionParams` compat flag for backwards compatibility with existing scripts.