### PR TITLE
Turbo boost

### DIFF
--- a/PEBakery.Core/CodeParser.cs
+++ b/PEBakery.Core/CodeParser.cs
@@ -40,6 +40,14 @@ namespace PEBakery.Core
         #region Fields and Properties
         private readonly ScriptSection _section;
         private readonly Options _opts;
+
+        private static readonly Regex _NumericRegex =
+            new Regex(@"([0-9]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _AlphaNumericUnderscoreRegex = 
+            new Regex(@"^[A-Za-z0-9_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _AlphaUnderscoreRegex =
+            new Regex(@"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         #endregion
 
         #region Options
@@ -357,7 +365,7 @@ namespace PEBakery.Core
             macroType = null;
 
             // There must be no number in typeStr
-            if (!Regex.IsMatch(typeStr, @"^[A-Za-z0-9_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaNumericUnderscoreRegex.IsMatch(typeStr))
                 throw new InvalidCommandException($"Invalid CodeType [{typeStr}], Only alphabet, number and underscore can be used as CodeType");
 
             bool isMacro = !Enum.TryParse(typeStr, true, out CodeType type) ||
@@ -2712,7 +2720,7 @@ namespace PEBakery.Core
         public static RegMultiType ParseRegMultiType(string typeStr)
         {
             // There must be no number in typeStr
-            if (!Regex.IsMatch(typeStr, @"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaUnderscoreRegex.IsMatch(typeStr))
                 throw new InvalidCommandException($"Wrong RegMultiType [{typeStr}], Only alphabet and underscore can be used as RegMultiType");
 
             bool invalid = !Enum.TryParse(typeStr, true, out RegMultiType type) ||
@@ -2728,7 +2736,7 @@ namespace PEBakery.Core
         #region ParseInterfaceElement
         public static InterfaceElement ParseInterfaceElement(string str)
         {
-            if (!Regex.IsMatch(str, @"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaUnderscoreRegex.IsMatch(str))
                 throw new InvalidCommandException($"Wrong InterfaceElement [{str}], Only alphabet and underscore can be used");
 
             bool invalid = !Enum.TryParse(str, true, out InterfaceElement e) ||
@@ -2810,7 +2818,7 @@ namespace PEBakery.Core
         public static UserInputType ParseUserInputType(string typeStr)
         {
             // There must be no number in typeStr
-            if (!Regex.IsMatch(typeStr, @"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaUnderscoreRegex.IsMatch(typeStr))
                 throw new InvalidCommandException($"Wrong CodeType [{typeStr}], Only alphabet and underscore can be used as UserInputType");
 
             bool invalid = !Enum.TryParse(typeStr, true, out UserInputType type) ||
@@ -3142,7 +3150,7 @@ namespace PEBakery.Core
         public static StrFormatType ParseStrFormatType(string typeStr)
         {
             // There must be no number in typeStr
-            if (!Regex.IsMatch(typeStr, @"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaUnderscoreRegex.IsMatch(typeStr))
                 throw new InvalidCommandException($"Wrong CodeType [{typeStr}], Only alphabet and underscore can be used as StrFormatType");
 
             bool invalid = !Enum.TryParse(typeStr, true, out StrFormatType type) ||
@@ -3575,7 +3583,7 @@ namespace PEBakery.Core
         public static MathType ParseMathType(string typeStr)
         {
             // There must be no number in typeStr
-            if (!Regex.IsMatch(typeStr, @"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaUnderscoreRegex.IsMatch(typeStr))
                 throw new InvalidCommandException($"Wrong CodeType [{typeStr}], Only alphabet and underscore can be used as MathType");
 
             bool invalid = !Enum.TryParse(typeStr, true, out MathType type) ||
@@ -3958,7 +3966,7 @@ namespace PEBakery.Core
         public static ListType ParseListType(string typeStr)
         {
             // There must be no number in typeStr
-            if (!Regex.IsMatch(typeStr, @"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaUnderscoreRegex.IsMatch(typeStr))
                 throw new InvalidCommandException($"Wrong CodeType [{typeStr}], Only alphabet and underscore can be used as ListType");
 
             bool invalid = !Enum.TryParse(typeStr, true, out ListType type) ||
@@ -4238,7 +4246,7 @@ namespace PEBakery.Core
         public static SystemType ParseSystemType(string typeStr)
         {
             // There must be no number in typeStr
-            if (!Regex.IsMatch(typeStr, @"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaUnderscoreRegex.IsMatch(typeStr))
                 throw new InvalidCommandException($"Wrong CodeType [{typeStr}], Only alphabet and underscore can be used as SystemType");
 
             bool invalid = !Enum.TryParse(typeStr, true, out SystemType type) ||
@@ -4289,7 +4297,7 @@ namespace PEBakery.Core
         public static DebugType ParseDebugType(string typeStr)
         {
             // There must be no number in typeStr
-            if (!Regex.IsMatch(typeStr, @"^[A-Za-z_]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (!_AlphaUnderscoreRegex.IsMatch(typeStr))
                 throw new InvalidCommandException($"Wrong CodeType [{typeStr}], Only alphabet and underscore can be used as DebugType");
 
             bool invalid = !Enum.TryParse(typeStr, true, out DebugType type) ||
@@ -4426,7 +4434,7 @@ namespace PEBakery.Core
                 }
                 else if (condStr.Equals("Question", StringComparison.OrdinalIgnoreCase))
                 {
-                    Match m = Regex.Match(args[cIdx + 2], @"([0-9]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+                    Match m = _NumericRegex.Match(args[cIdx + 2]);
                     if (m.Success)
                     {
                         embIdx = cIdx + 4;
@@ -4547,9 +4555,9 @@ namespace PEBakery.Core
         #region ParseCodeInfoIf, ForgeIfEmbedCommand
         public static bool StringContainsVariable(string str)
         {
-            MatchCollection matches = Regex.Matches(str, Variables.VarKeyRegexContainsVariable, RegexOptions.Compiled | RegexOptions.CultureInvariant); // ABC%Joveler%
-            bool sectionInParamMatch = Regex.IsMatch(str, Variables.VarKeyRegexContainsLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #1
-            bool sectionOutParamMatch = Regex.IsMatch(str, Variables.VarKeyRegexContainsLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #o1
+            MatchCollection matches = Variables.ContainsVariableRegex.Matches(str); // ABC%Joveler%
+            bool sectionInParamMatch = Variables.ContainsLegacySectionInParamsRegex.IsMatch(str); // #1
+            bool sectionOutParamMatch = Variables.ContainsLegacySectionOutParamsRegex.IsMatch(str); // #o1
             bool sectionLoopMatch = str.IndexOf("#c", StringComparison.OrdinalIgnoreCase) != -1; // #c
             bool sectionInParamCountMatch = str.IndexOf("#a", StringComparison.OrdinalIgnoreCase) != -1; // #a
             bool sectionOutParamCountMatch = str.IndexOf("#oa", StringComparison.OrdinalIgnoreCase) != -1; // #oa
@@ -4567,15 +4575,15 @@ namespace PEBakery.Core
         {
             HashSet<string> refSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            MatchCollection matches = Regex.Matches(str, Variables.VarKeyRegexContainsVariable, RegexOptions.Compiled | RegexOptions.CultureInvariant); // ABC%Joveler%
+            MatchCollection matches = Variables.ContainsVariableRegex.Matches(str); // ABC%Joveler%
             if (0 < matches.Count)
                 refSet.Add(matches[0].Value);
 
-            matches = Regex.Matches(str, Variables.VarKeyRegexContainsLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #1
+            matches = Variables.ContainsLegacySectionInParamsRegex.Matches(str); // #1
             if (0 < matches.Count)
                 refSet.Add(matches[0].Value);
 
-            matches = Regex.Matches(str, Variables.VarKeyRegexContainsLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant); // #o1
+            matches = Variables.ContainsLegacySectionOutParamsRegex.Matches(str); // #o1
             if (0 < matches.Count)
                 refSet.Add(matches[0].Value);
 

--- a/PEBakery.Core/Commands/CommandControl.cs
+++ b/PEBakery.Core/Commands/CommandControl.cs
@@ -46,8 +46,8 @@ namespace PEBakery.Core.Commands
             if (varType == Variables.VarKeyType.None)
             {
                 // Check Macro
-                if (Regex.Match(info.VarKey, Macro.MacroNameRegex,
-                    RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Macro Name Validation
+                Match match = Macro.MacroNameRegex.Match(info.VarKey);
+                if (match.Success) // Macro Name Validation
                 {
                     string? macroCommand = StringEscaper.Preprocess(s, info.VarValue);
 

--- a/PEBakery.Core/Commands/CommandString.cs
+++ b/PEBakery.Core/Commands/CommandString.cs
@@ -42,6 +42,11 @@ namespace PEBakery.Core.Commands
         private const long MB = 1024L * 1024L;
         private const long KB = 1024L;
 
+        private static readonly Regex _DriveLetterRegex =
+            new Regex(@"^([a-zA-Z]:)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _NumericRegex =
+            new Regex(@"([0-9]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         public static List<LogInfo> StrFormat(EngineState s, CodeCommand cmd)
         {
             List<LogInfo> logs = new List<LogInfo>();
@@ -235,7 +240,7 @@ namespace PEBakery.Core.Commands
                         string dirPath = StringEscaper.Preprocess(s, subInfo.DirPath).Trim();
                         string fileName = StringEscaper.Preprocess(s, subInfo.FileName).Trim();
 
-                        if (Regex.IsMatch(dirPath, @"^([a-zA-Z]:)$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+                        if (_DriveLetterRegex.IsMatch(dirPath))
                             dirPath += @"\";
 
                         string destStr = Path.Combine(dirPath, fileName);
@@ -479,7 +484,7 @@ namespace PEBakery.Core.Commands
 
                         string srcStr = StringEscaper.Preprocess(s, subInfo.SrcStr);
 
-                        Match m = Regex.Match(srcStr, @"([0-9]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+                        Match m = _NumericRegex.Match(srcStr);
                         var destStr = m.Success ? srcStr[..m.Index] : srcStr;
 
                         List<LogInfo> varLogs = Variables.SetVariable(s, subInfo.DestVar, destStr);

--- a/PEBakery.Core/EncodedFile.cs
+++ b/PEBakery.Core/EncodedFile.cs
@@ -60,7 +60,7 @@ namespace PEBakery.Core
     * All bytes are ordered in little endian.
     * CodecWBZip[1] (Type 1 and 2) is equal to ZLBArchive v2 format.
     * WB082 only understands Type 1 and 2.
-    * Type 3 is a PEBakery externsion.
+    * Type 3 is a PEBakery extension.
 
     [1] This binary format was originally described by extensive blackbox testing, without breaking WB082 EULA.
         It was later revealed that this format was defined by ZLBArchive v2.
@@ -110,7 +110,7 @@ namespace PEBakery.Core
         WB082 did not use encryption feature, so this field is always 0.
     [3] Location of body field is used when ZLBArchive2 stores multiple files into one archive.
         WB082 always stored/compressed single file, so this field is always 0.
-    [4] Compress level field is not required to be valid for decompressison.
+    [4] Compress level field is not required to be valid for decompression.
 
     [ArchiveFooter]
     Not compressed, 36Byte (0x24)
@@ -152,6 +152,10 @@ namespace PEBakery.Core
 
         public const double CompReportFactor = 0.8;
         public const double Base64ReportFactor = 0.2;
+
+        private static readonly Regex _FileIndexRegex =
+            new Regex(@"([0-9]+),([0-9]+)", RegexOptions.Compiled | RegexOptions.CultureInvariant); 
+
         #endregion
 
         #region EncodeMode Methods
@@ -1018,7 +1022,7 @@ namespace PEBakery.Core
         /// </returns>
         private static (int rawSize, int encodedSize) ParseFileIndex(string fileIndex)
         {
-            Match m = Regex.Match(fileIndex, @"([0-9]+),([0-9]+)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match m = _FileIndexRegex.Match(fileIndex);
             if (!m.Success)
                 return (-1, -1);
 

--- a/PEBakery.Core/Engine.cs
+++ b/PEBakery.Core/Engine.cs
@@ -368,8 +368,8 @@ namespace PEBakery.Core
             if (section.Lines == null)
                 s.Logger.BuildWrite(s, new LogInfo(LogState.CriticalError, $"Unable to load section [{section.Name}]", newDepth));
 
-            CodeParser parser = new CodeParser(section, Global.Setting, s.Project.Compat);
-            (CodeCommand[] cmds, _) = parser.ParseStatements();
+            // Get Cmds from the Parsed Command Cache or Parse from lines if not cached
+            CodeCommand[] cmds = section.GetOrParseCmds(Global.Setting, s.Project.Compat);
 
             // Set CurrentSection
             s.CurrentSection = section;

--- a/PEBakery.Core/Macro.cs
+++ b/PEBakery.Core/Macro.cs
@@ -69,7 +69,8 @@ namespace PEBakery.Core
         public Dictionary<string, CodeCommand> LocalDict { get; private set; }
             = new Dictionary<string, CodeCommand>(StringComparer.OrdinalIgnoreCase);
 
-        public const string MacroNameRegex = @"^([a-zA-Z0-9_]+)$";
+        public static readonly Regex MacroNameRegex =
+            new Regex(@"^([a-zA-Z0-9_]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         #endregion
 
         #region Constructor
@@ -129,7 +130,7 @@ namespace PEBakery.Core
                 {
                     try
                     {
-                        if (Regex.Match(kv.Key, MacroNameRegex, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success)
+                        if (MacroNameRegex.IsMatch(kv.Key))
                         { // Macro Name Validation
                             CodeParser parser = new CodeParser(section, Global.Setting, section.Project.Compat);
                             GlobalDict[kv.Key] = parser.ParseStatement(kv.Value);
@@ -156,7 +157,7 @@ namespace PEBakery.Core
                 {
                     try
                     {
-                        if (Regex.Match(kv.Key, MacroNameRegex, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success)
+                        if (MacroNameRegex.IsMatch(kv.Key))
                         { // Macro Name Validation
                             CodeParser parser = new CodeParser(permaSection, Global.Setting, permaSection.Project.Compat);
                             GlobalDict[kv.Key] = parser.ParseStatement(kv.Value);
@@ -229,7 +230,7 @@ namespace PEBakery.Core
                 try
                 {
                     // Macro Name Validation
-                    if (!Regex.Match(kv.Key, MacroNameRegex, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success)
+                    if (!MacroNameRegex.IsMatch(kv.Key))
                     {
                         logs.Add(new LogInfo(LogState.Error, $"Invalid macro name [{kv.Key}]"));
                         continue;
@@ -307,7 +308,7 @@ namespace PEBakery.Core
         public LogInfo SetMacro(string macroName, string? macroCommand, ScriptSection section, bool global, bool permanent)
         {
             // Macro Name Validation
-            if (!Regex.Match(macroName, MacroNameRegex, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success)
+            if (!MacroNameRegex.IsMatch(macroName))
                 return new LogInfo(LogState.Error, $"Invalid macro name [{macroName}]");
 
             if (macroCommand != null)

--- a/PEBakery.Core/ScriptSection.cs
+++ b/PEBakery.Core/ScriptSection.cs
@@ -224,6 +224,16 @@ namespace PEBakery.Core
         private CodeCommand[]? _cachedCmds;
         [IgnoreMember]
         private readonly object _parseLock = new object();
+
+        // Static Regex
+        private static readonly Regex _DeepInspectCodeRegex =
+            new Regex(@"^(([A-Za-z0-9_]+[ ]*(,.+)*)|End|Break|Continue)$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        private static readonly Regex _DeepInspectInterfaceCtrlRegex =
+            new Regex(@"^([^%=\r\n]+)=(.*,[0-9]+,[0-9]+,[0-9]+,[0-9]+,[0-9]+,[0-9]+.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _DeepInspectVarRegex =
+            new Regex(@"^(%[^=\r\n]+%)=(.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _DeepInspectIniRegex =
+            new Regex(@"^([^=\r\n]+)=(.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         #endregion
 
         #region Constructor
@@ -486,19 +496,19 @@ namespace PEBakery.Core
                 totalLineCount += 1;
 
                 // Is this line a code?
-                if (Regex.IsMatch(line, "^(([A-Za-z0-9_]+[ ]*(,.+)*)|End|Break|Continue)$", RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase))
+                if (_DeepInspectCodeRegex.IsMatch(line))
                     codeMatchCount += 1;
 
                 // Is this line an interface Control?
-                if (Regex.IsMatch(line, "^([^%=\r\n]+)=(.*,[0-9]+,[0-9]+,[0-9]+,[0-9]+,[0-9]+,[0-9]+.*)$", RegexOptions.CultureInvariant | RegexOptions.Compiled))
+                if (_DeepInspectInterfaceCtrlRegex.IsMatch(line))
                     ifaceMatchCount += 1;
 
                 // Is this line a var-style line?
-                if (Regex.IsMatch(line, "^(%[^=\r\n]+%)=(.*)$", RegexOptions.CultureInvariant | RegexOptions.Compiled))
+                if (_DeepInspectVarRegex.IsMatch(line))
                     varMatchCount += 1;
 
                 // Is this line a simple ini-style line?
-                if (Regex.IsMatch(line, "^([^=\r\n]+)=(.*)$", RegexOptions.CultureInvariant | RegexOptions.Compiled))
+                if (_DeepInspectIniRegex.IsMatch(line))
                     iniMatchCount += 1;
             }
 

--- a/PEBakery.Core/ScriptSection.cs
+++ b/PEBakery.Core/ScriptSection.cs
@@ -218,6 +218,12 @@ namespace PEBakery.Core
                 throw new InvalidOperationException($"Section [{Name}] is not an ini-type section");
             }
         }
+
+        // Parsed command cache
+        [IgnoreMember]
+        private CodeCommand[]? _cachedCmds;
+        [IgnoreMember]
+        private readonly object _parseLock = new object();
         #endregion
 
         #region Constructor
@@ -294,6 +300,7 @@ namespace PEBakery.Core
         {
             _lines = null;
             _iniDict = null;
+            InvalidateParsedCache();
         }
 
         /// <summary>
@@ -346,6 +353,7 @@ namespace PEBakery.Core
                 _lines[^1] = $"{key}={value}";
             }
 
+            InvalidateParsedCache();
             return true;
         }
 
@@ -383,7 +391,34 @@ namespace PEBakery.Core
                 _lines = newLines.ToArray();
             }
 
+            InvalidateParsedCache();
             return true;
+        }
+        #endregion
+
+        #region Parsed Command Cache
+        /// <summary>
+        /// Returns parsed CodeCommands for this section, caching the result so repeated calls
+        /// (e.g. a macro invoked hundreds of times) do not re-parse the same lines every time.
+        /// </summary>
+        public CodeCommand[] GetOrParseCmds(Setting setting, CompatOption compat)
+        {
+            if (_cachedCmds != null) return _cachedCmds;
+            lock (_parseLock)
+            {
+                if (_cachedCmds != null) return _cachedCmds;
+                CodeParser parser = new CodeParser(this, setting, compat);
+                (_cachedCmds, _) = parser.ParseStatements();
+                return _cachedCmds;
+            }
+        }
+
+        /// <summary>
+        /// Discards the cached parsed commands. Call whenever _lines is changed.
+        /// </summary>
+        private void InvalidateParsedCache()
+        {
+            _cachedCmds = null;
         }
         #endregion
 
@@ -440,7 +475,7 @@ namespace PEBakery.Core
             int totalLineCount = 0;
 
             // Check the type of a line using regexes.
-            // Even though regex does have some errors, regexes are used for its simplexity and speed advantage.
+            // Even though regex does have some errors, regexes are used for its simplicity and speed advantage.
             // TODO: How many times running a precise parsers like CodeParser/UIParser/IniReadWriter are slower than regexes?
             foreach (string line in Lines.Where(x => 0 < x.Length))
             {

--- a/PEBakery.Core/StringEscaper.cs
+++ b/PEBakery.Core/StringEscaper.cs
@@ -50,6 +50,28 @@ namespace PEBakery.Core
         };
 
         private static readonly char[] WildcardCharacters = new char[] { '*', '?' };
+
+        // Static RegEx:
+        private static readonly Regex _SectionInParamRegex =
+            new Regex(@"(?<!#)(#[1-9])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _SectionOutParamRegex =
+            new Regex(@"(?<!#)(#[oO][1-9])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _SectionInParamCountRegex =
+            new Regex(@"(?<!#)(#[aA])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _SectionOutParamCountRegex =
+            new Regex(@"(?<!#)(#[oO][aA])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _ReturnValueRegex =
+            new Regex(@"(?<!#)(#[rR])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _LoopCounterRegex =
+            new Regex(@"(?<!#)(#[cC])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _PercentPatternParamRegex =
+            new Regex(@"%\^([A-Za-z0-9_]+)%", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _SectVarNameRegex =
+            new Regex(@"^(S(?:I|O)PARAM)_([1-9][0-9]*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        private static readonly Regex _IsPathValidRootRegex =
+            new Regex("^[A-Za-z]:", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _IsFilterValidRegex =
+            new Regex(@"^([^\|\r\n]+)\|([^\|\r\n]+)+(\|([^\|\r\n]+)\|([^\|\r\n]+))*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         #endregion
 
         #region PathSecurityCheck
@@ -104,7 +126,7 @@ namespace PEBakery.Core
             char[] invalidChars = [.. Path.GetInvalidFileNameChars().Where(x => x != '\\')];
 
             // Ex) "C:\Program Files"
-            Match m = Regex.Match(path, "^[A-Za-z]:", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match m = _IsPathValidRootRegex.Match(path);
             if (m.Success)
             {
                 for (int i = 0; i < path.Length; i++)
@@ -187,8 +209,8 @@ namespace PEBakery.Core
 
             // Valid format = [<DisplayText>|<wildcard1>;<wildcard2>;...] | [<DisplayText>|<wildcard1>;<wildcard2>;...]
             //                           Txt Files     | *.txt;*.log   | All Files   | *.*
-            const string filterRegex = @"^([^\|\r\n]+)\|([^\|\r\n]+)+(\|([^\|\r\n]+)\|([^\|\r\n]+))*$";
-            return Regex.IsMatch(filter, filterRegex, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            //                         @"^([^\|\r\n]+)\|([^\|\r\n]+)+(\|([^\|\r\n]+)\|([^\|\r\n]+))*$";
+            return _IsFilterValidRegex.IsMatch(filter);
         }
 
         /// <summary>
@@ -486,8 +508,7 @@ namespace PEBakery.Core
         public static string ExpandLegacySharpSectionParams(EngineState s, string str)
         {
             // Expand #1 into its value
-            Regex inRegex = new Regex(@"(?<!#)(#[1-9])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-            MatchCollection matches = inRegex.Matches(str);
+            MatchCollection matches = _SectionInParamRegex.Matches(str);
             while (0 < matches.Count)
             {
                 StringBuilder b = new StringBuilder();
@@ -529,7 +550,7 @@ namespace PEBakery.Core
                 }
                 str = b.ToString();
 
-                matches = inRegex.Matches(str);
+                matches = _SectionInParamRegex.Matches(str);
             }
 
             if (!s.CompatDisableLegacyExtendedSectionParams)
@@ -537,8 +558,7 @@ namespace PEBakery.Core
                 // Expand #o1, #o2, ... (Section Out Parameter)
                 if (s.CurSectionOutParams != null)
                 {
-                    Regex outRegex = new Regex(@"(?<!#)(#[oO][1-9])", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-                    matches = outRegex.Matches(str);
+                    matches = _SectionOutParamRegex.Matches(str);
                     while (0 < matches.Count)
                     {
                         StringBuilder b = new StringBuilder();
@@ -578,21 +598,21 @@ namespace PEBakery.Core
                         }
                         str = b.ToString();
 
-                        matches = inRegex.Matches(str);
+                        matches = _SectionOutParamRegex.Matches(str);
                     }
                 }
 
                 // Expand #a (Section In Params Count)
                 if (str.Contains("#a", StringComparison.OrdinalIgnoreCase))
-                    str = StringHelper.ReplaceRegex(str, @"(?<!#)(#[aA])", s.CurSectionInParamsCount.ToString());
+                    str = StringHelper.ReplaceRegex(str, _SectionInParamCountRegex, s.CurSectionInParamsCount.ToString());
 
                 // Expand #oa (Section Out Params Count)
                 if (str.Contains("#oa", StringComparison.OrdinalIgnoreCase))
-                    str = StringHelper.ReplaceRegex(str, @"(?<!#)(#[oO][aA])", s.CurSectionInParamsCount.ToString());
+                    str = StringHelper.ReplaceRegex(str, _SectionOutParamCountRegex, s.CurSectionInParamsCount.ToString());
 
                 // Expand #r (Return Value)
                 if (str.Contains("#r", StringComparison.OrdinalIgnoreCase))
-                    str = StringHelper.ReplaceRegex(str, @"(?<!#)(#[rR])", s.ReturnValue);
+                    str = StringHelper.ReplaceRegex(str, _ReturnValueRegex, s.ReturnValue);
             }
 
             // Expand #c (Loop Counter)
@@ -602,10 +622,10 @@ namespace PEBakery.Core
                 switch (loop.State)
                 {
                     case LoopCmdState.OnIndex:
-                        str = StringHelper.ReplaceRegex(str, @"(?<!#)(#[cC])", loop.CounterIndex.ToString());
+                        str = StringHelper.ReplaceRegex(str, _LoopCounterRegex, loop.CounterIndex.ToString());
                         break;
                     case LoopCmdState.OnDriveLetter:
-                        str = StringHelper.ReplaceRegex(str, @"(?<!#)(#[cC])", loop.CounterLetter.ToString());
+                        str = StringHelper.ReplaceRegex(str, _LoopCounterRegex, loop.CounterLetter.ToString());
                         break;
                 }
             }
@@ -638,12 +658,10 @@ namespace PEBakery.Core
         public static string ExpandPercentPatternSectionParams(EngineState s, string str)
         {
             // Expand #1 into its value
-            Regex paramRegex = new Regex(@"%\^([A-Za-z0-9_]+)%", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-            Regex pSectVarRegex = new Regex(@"^(S(?:I|O)PARAM)_([1-9][0-9]*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
             StringBuilder b = new StringBuilder();
 
             int lastCopiedIdx = 0;
-            MatchCollection matches = paramRegex.Matches(str);
+            MatchCollection matches = _PercentPatternParamRegex.Matches(str);
             if (matches.Count == 0)
                 return str;
 
@@ -697,7 +715,7 @@ namespace PEBakery.Core
                 }
                 else
                 {
-                    Match pSectMatch = pSectVarRegex.Match(paramNameStr);
+                    Match pSectMatch = _SectVarNameRegex.Match(paramNameStr);
                     string pKind = pSectMatch.Groups[1].Value;
                     string pIdxStr = pSectMatch.Groups[2].Value;
 

--- a/PEBakery.Core/Variables.cs
+++ b/PEBakery.Core/Variables.cs
@@ -605,6 +605,9 @@ namespace PEBakery.Core
         #endregion
 
         #region Expand
+        private static readonly Regex ExpandVarRegex =
+            new Regex(@"%([^ %]+)%", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         public string Expand(string str)
         {
             int iteration = 0;
@@ -615,7 +618,8 @@ namespace PEBakery.Core
                 // Expand variable's name into value
                 // Ex) 123%BaseDir%456%OS%789
                 StringBuilder b = new StringBuilder();
-                matches = Regex.Matches(str, @"%([^ %]+)%", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+                matches = ExpandVarRegex.Matches(str);
                 for (int x = 0; x < matches.Count; x++)
                 {
                     string varName = matches[x].Groups[1].Value;
@@ -770,6 +774,28 @@ namespace PEBakery.Core
         public const string VarKeyRegexLegacySectionOutParams = @"^" + VarKeyRegexContainsLegacySectionOutParams + @"$";
         public const string VarKeyRegexPercentSectionInParams = @"^" + VarKeyRegexContainsPercentSectionInParams + @"$";
         public const string VarKeyRegexPercentSectionOutParams = @"^" + VarKeyRegexContainsPercentSectionOutParams + @"$";
+        
+        public static readonly Regex ContainsVariableRegex =
+            new Regex(VarKeyRegexContainsVariable, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex ContainsLegacySectionInParamsRegex =
+            new Regex(VarKeyRegexLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex ContainsLegacySectionOutParamsRegex =
+            new Regex(VarKeyRegexLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex ContainsPercentSectionInParamsRegex =
+            new Regex(VarKeyRegexPercentSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex ContainsPercentSectionOutParamsRegex =
+            new Regex(VarKeyRegexPercentSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex VariableRegex =
+            new Regex(VarKeyRegexVariable, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex LegacySectionInParamsRegex =
+            new Regex(VarKeyRegexContainsLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex LegacySectionOutParamsRegex =
+            new Regex(VarKeyRegexContainsLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex PercentSectionInParamsRegex =
+            new Regex(VarKeyRegexPercentSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        public static readonly Regex PercentSectionOutParamsRegex =
+            new Regex(VarKeyRegexPercentSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         public enum VarKeyType
         {
             None,
@@ -779,18 +805,18 @@ namespace PEBakery.Core
             ReturnValuePercent, ReturnValueLegacy,
             LoopCounterPercent, LoopCounterLegacy
         }
-
+                 
         public static VarKeyType DetectType(string key)
         {
-            if (Regex.Match(key, VarKeyRegexVariable, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) %A%
+            if (VariableRegex.IsMatch(key)) // Ex) %A%
                 return VarKeyType.Variable;  // %#[0-9]+% -> Compatibility Shim
-            if (Regex.Match(key, VarKeyRegexPercentSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) %^SIPARAM_1%, %^SIPARAM_1%, ...
+            if (PercentSectionInParamsRegex.IsMatch(key)) // Ex) %^SIPARAM_1%, %^SIPARAM_1%, ...
                 return VarKeyType.SectionInParamsPercent;
-            if (Regex.Match(key, VarKeyRegexLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) #1, #2, #3, ...
+            if (LegacySectionInParamsRegex.IsMatch(key)) // Ex) #1, #2, #3, ...
                 return VarKeyType.SectionInParamsLegacy;
-            if (Regex.Match(key, VarKeyRegexPercentSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) %^SOPARAM_1%, %^SOPARAM_2%, %^SOPARAM_3% ...
+            if (PercentSectionOutParamsRegex.IsMatch(key)) // Ex) %^SOPARAM_1%, %^SOPARAM_2%, %^SOPARAM_3% ...
                 return VarKeyType.SectionOutParamsPercent;
-            if (Regex.Match(key, VarKeyRegexLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant).Success) // Ex) #o1, #o2, #o3, ...
+            if (LegacySectionOutParamsRegex.IsMatch(key)) // Ex) #o1, #o2, #o3, ...
                 return VarKeyType.SectionOutParamsLegacy;
             if (key.Equals("%^RET%", StringComparison.OrdinalIgnoreCase)) // Return Value
                 return VarKeyType.ReturnValuePercent;
@@ -805,7 +831,7 @@ namespace PEBakery.Core
 
         public static int GetPercentSectionInParamIndex(string secParam)
         {
-            Match match = Regex.Match(secParam, VarKeyRegexContainsPercentSectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match match = ContainsPercentSectionInParamsRegex.Match(secParam);
             if (match.Success)
             {
                 if (NumberHelper.ParseInt32(match.Groups[1].Value, out int paramIdx))
@@ -819,7 +845,7 @@ namespace PEBakery.Core
 
         public static int GetLegacySectionInParamIndex(string secParam)
         {
-            Match match = Regex.Match(secParam, VarKeyRegexContainsLegacySectionInParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match match = ContainsLegacySectionInParamsRegex.Match(secParam);
             if (match.Success)
             {
                 if (NumberHelper.ParseInt32(secParam[1..], out int paramIdx))
@@ -833,7 +859,7 @@ namespace PEBakery.Core
 
         public static int GetPercentSectionOutParamIndex(string secParam)
         {
-            Match match = Regex.Match(secParam, VarKeyRegexContainsPercentSectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match match = ContainsPercentSectionOutParamsRegex.Match(secParam);
             if (match.Success)
             {
                 if (NumberHelper.ParseInt32(match.Groups[1].Value, out int paramIdx))
@@ -847,7 +873,7 @@ namespace PEBakery.Core
 
         public static int GetLegacySectionOutParamIndex(string secParam)
         {
-            Match match = Regex.Match(secParam, VarKeyRegexContainsLegacySectionOutParams, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match match = ContainsLegacySectionOutParamsRegex.Match(secParam);
             if (match.Success)
             {
                 if (NumberHelper.ParseInt32(secParam[2..], out int paramIdx))
@@ -1099,7 +1125,7 @@ namespace PEBakery.Core
                     {
                         if (s.Variables.Exists(VarsType.Fixed, key))
                         {
-                            logs.Add(new LogInfo(LogState.Warning, $"Fixed variable [{varKey}] cannot be overriden"));
+                            logs.Add(new LogInfo(LogState.Warning, $"Fixed variable [{varKey}] cannot be overridden"));
                             return logs;
                         }
                     }
@@ -1222,7 +1248,7 @@ namespace PEBakery.Core
 
                     if (!s.CompatOverridableLoopCounter)
                     {
-                        logs.Add(new LogInfo(LogState.Warning, $"LoopCounter [{symbol}] cannot be overriden"));
+                        logs.Add(new LogInfo(LogState.Warning, $"LoopCounter [{symbol}] cannot be overridden"));
                         return logs;
                     }
 

--- a/PEBakery.Helper/NumberHelper.cs
+++ b/PEBakery.Helper/NumberHelper.cs
@@ -33,6 +33,15 @@ namespace PEBakery.Helper
 {
     public static class NumberHelper
     {
+        #region Static
+        private static readonly Regex _Base10IntegerRegex =
+            new Regex(@"^[0-9]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _Base16IntegerRegex =
+            new Regex(@"^0x[0-9a-zA-Z]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _RealNumberRegex =
+            new Regex(@"^([0-9]+)\.([0-9]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        #endregion
+
         #region IsStringHexInteger
         public enum StringNumberType
         {
@@ -362,7 +371,7 @@ namespace PEBakery.Helper
                 return ParseStringToNumberType.String;
 
             // base 10 integer - Z
-            if (Regex.IsMatch(str, @"^[0-9]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (_Base10IntegerRegex.IsMatch(str))
             {
                 if (long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out integer))
                     return ParseStringToNumberType.Integer;
@@ -370,7 +379,7 @@ namespace PEBakery.Helper
                     return ParseStringToNumberType.String;
             }
             // base 16 integer - Z
-            if (Regex.IsMatch(str, @"^0x[0-9a-zA-Z]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (_Base16IntegerRegex.IsMatch(str))
             {
                 if (long.TryParse(str.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out integer))
                     return ParseStringToNumberType.Integer;
@@ -379,7 +388,7 @@ namespace PEBakery.Helper
             }
 
             // real number - R
-            if (Regex.IsMatch(str, @"^([0-9]+)\.([0-9]+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant))
+            if (_RealNumberRegex.IsMatch(str))
             {
                 if (decimal.TryParse(str, NumberStyles.AllowDecimalPoint | NumberStyles.Integer, CultureInfo.InvariantCulture, out real))
                     return ParseStringToNumberType.Decimal;

--- a/PEBakery.Helper/RegistryHelper.cs
+++ b/PEBakery.Helper/RegistryHelper.cs
@@ -269,8 +269,8 @@ namespace PEBakery.Helper
 
         public static uint? ValueKindToWBInt(RegistryValueKind valueType)
         {
-            if (ValueKindWBIntDict.ContainsKey(valueType))
-                return ValueKindWBIntDict[valueType];    
+            if (ValueKindWBIntDict.TryGetValue(valueType, out uint wbInt))
+                return wbInt;
             return null;
         }
 

--- a/PEBakery.Helper/StringHelper.cs
+++ b/PEBakery.Helper/StringHelper.cs
@@ -49,12 +49,15 @@ namespace PEBakery.Helper
         #endregion
 
         #region Is{Hex|Alphabet|...}
+        private static readonly Regex _IsHexRegex =
+           new Regex(@"^[A-Fa-f0-9]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         public static bool IsHex(string str)
         {
             if (str.Length % 2 == 1)
                 return false;
 
-            return Regex.IsMatch(str, @"^[A-Fa-f0-9]+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            return _IsHexRegex.IsMatch(str);
         }
 
         public static bool IsUpperAlphabet(string str)
@@ -238,6 +241,37 @@ namespace PEBakery.Helper
             if (ignoreCase)
                 opts |= RegexOptions.IgnoreCase;
             MatchCollection matches = Regex.Matches(str, regex, opts);
+            if (matches.Count == 0)
+                return str;
+
+            StringBuilder b = new StringBuilder();
+            for (int x = 0; x < matches.Count; x++)
+            {
+                if (x == 0)
+                {
+                    b.Append(str[..matches[0].Index]);
+                }
+                else
+                {
+                    int startOffset = matches[x - 1].Index + matches[x - 1].Value.Length;
+                    int endOffset = matches[x].Index - startOffset;
+                    b.Append(str.AsSpan(startOffset, endOffset));
+                }
+
+                b.Append(newValue);
+
+                if (x + 1 == matches.Count)
+                {
+                    int startOffset = matches[x].Index + matches[x].Value.Length;
+                    b.Append(str[startOffset..]);
+                }
+            }
+            return b.ToString();
+        }
+
+        public static string ReplaceRegex(string str, Regex regex, string newValue)
+        {
+            MatchCollection matches = regex.Matches(str);
             if (matches.Count == 0)
                 return str;
 


### PR DESCRIPTION
## Overview
This PR introduces two significant performance optimizations to script command and macro processing.

In a stock PhoenixPE build, these changes drastically reduce overall build times from **7 minutes down to 2 minutes** (a ~71% speedup).

## Changes
1. **ScriptSection Caching**: Attempted to speed up script command/macro processing by caching the parsed `CodeCommand[]` array upon the first `ScriptSection` call. Subsequent calls now reuse this cached array instead of re-parsing.
   * **Impact:** Reduced `ParseStatements()` CPU execution time from **509ms to 137ms**.
2. **Regex Pre-compilation**: Converted all inline literal regex definitions into `static` pre-compiled fields. 
   * **Impact:** Eliminates repetitive regex compilation overhead during execution, driving the bulk of the 5-minute build-time reduction.
