### PR TITLE
Save the Project tree state

### DIFF
--- a/PEBakery.Core/Commands/CommandSystem.cs
+++ b/PEBakery.Core/Commands/CommandSystem.cs
@@ -215,7 +215,8 @@ namespace PEBakery.Core.Commands
                 case SystemType.RefreshAllScripts:
                     {
                         // Refresh Project
-                        s.MainViewModel.StartLoadingProjects(true, true).Wait();
+                        TreeViewState treeState = s.MainViewModel.CaptureMainTreeState();
+                        s.MainViewModel.StartLoadingProjects(true, true, treeState).Wait();
 
                         logs.Add(new LogInfo(LogState.Success, $"Reload project [{cmd.Section.Script.Project.ProjectName}]"));
                     }

--- a/PEBakery.Core/Setting.cs
+++ b/PEBakery.Core/Setting.cs
@@ -126,6 +126,12 @@ namespace PEBakery.Core
             public int MainWindowHeight { get; set; }
             public int MainTreeViewWidth { get; set; }
 
+            // Main tree view state (not shown in SettingsWindow)
+            /// <summary>RealPath of the script that was selected when the program last closed.</summary>
+            public string MainTreeSelectedScript { get; set; } = string.Empty;
+            /// <summary>Pipe '|' separated list of RealPaths for expanded tree nodes.</summary>
+            public string MainTreeExpandedNodes { get; set; } = string.Empty;
+
             public InterfaceSetting()
             {
                 Default();
@@ -147,6 +153,8 @@ namespace PEBakery.Core
                 MainWindowWidth = 900;
                 MainWindowHeight = 720;
                 MainTreeViewWidth = 200;
+                MainTreeSelectedScript = string.Empty;
+                MainTreeExpandedNodes = string.Empty;
             }
         }
 
@@ -697,6 +705,8 @@ namespace PEBakery.Core
                 new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainWindowWidth)), // Integer (600 -)
                 new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainWindowHeight)), // Integer (480 -)
                 new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainTreeViewWidth)), // Integer (100 - 300)
+                new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainTreeSelectedScript)), // String
+                new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainTreeExpandedNodes)),  // String
                 // Theme
                 new IniKey(ThemeSetting.SectionName, nameof(Theme.ThemeType)), // Enum (ThemeType)
                 new IniKey(ThemeSetting.SectionName, nameof(Theme.CustomTopPanelBackground)), // Color
@@ -818,6 +828,8 @@ namespace PEBakery.Core
                 Interface.MainWindowWidth = SettingDictParser.ParseInteger(ifaceDict, InterfaceSetting.SectionName, nameof(Interface.MainWindowWidth), Interface.MainWindowWidth, 600, screenArea.Width);
                 Interface.MainWindowHeight = SettingDictParser.ParseInteger(ifaceDict, InterfaceSetting.SectionName, nameof(Interface.MainWindowHeight), Interface.MainWindowHeight, 480, screenArea.Height);
                 Interface.MainTreeViewWidth = SettingDictParser.ParseInteger(ifaceDict, InterfaceSetting.SectionName, nameof(Interface.MainTreeViewWidth), Interface.MainTreeViewWidth, 100, 300);
+                Interface.MainTreeSelectedScript = SettingDictParser.ParseString(ifaceDict, nameof(Interface.MainTreeSelectedScript), Interface.MainTreeSelectedScript);
+                Interface.MainTreeExpandedNodes  = SettingDictParser.ParseString(ifaceDict, nameof(Interface.MainTreeExpandedNodes),  Interface.MainTreeExpandedNodes);
             }
 
             // Theme
@@ -913,6 +925,8 @@ namespace PEBakery.Core
                 new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainWindowWidth), Interface.MainWindowWidth.ToString()), // Integer
                 new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainWindowHeight), Interface.MainWindowHeight.ToString()), // Integer
                 new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainTreeViewWidth), Interface.MainTreeViewWidth.ToString()), // Integer
+                new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainTreeSelectedScript), Interface.MainTreeSelectedScript), // String
+                new IniKey(InterfaceSetting.SectionName, nameof(Interface.MainTreeExpandedNodes),  Interface.MainTreeExpandedNodes),  // String
                 // Theme
                 new IniKey(ThemeSetting.SectionName, nameof(Theme.ThemeType), Theme.ThemeType.ToString()), // String
                 new IniKey(ThemeSetting.SectionName, nameof(Theme.CustomTopPanelBackground), WriteColor(Theme.CustomTopPanelBackground)), // Color

--- a/PEBakery.Core/ViewModels/MainViewModel.cs
+++ b/PEBakery.Core/ViewModels/MainViewModel.cs
@@ -94,6 +94,13 @@ namespace PEBakery.Core.ViewModels
             }
         }
         public ProjectTreeItemModel? CurBuildTree { get; set; }
+
+        /// <summary>
+        /// Scroll the selected tree item into view after a state restore.
+        /// Called from within the ContextIdle dispatch (in code behind) so the tree is
+        /// already rendered before we try to locate and scroll to the container.
+        /// </summary>
+        public Action? BringTreeSelectionIntoViewAction { get; set; }
         #endregion
 
         #region Working Properties
@@ -904,7 +911,101 @@ namespace PEBakery.Core.ViewModels
         #endregion
 
         #region Background Tasks
-        public Task StartLoadingProjects(bool refreshProjectEntries, bool quiet)
+        #region TreeViewState Save/Restore
+        /// <summary>
+        /// Walk the entire main tree and returns a snapshot of which nodes are
+        /// expanded and which script is currently selected.
+        /// </summary>
+        public TreeViewState CaptureMainTreeState()
+        {
+            TreeViewState state = new TreeViewState
+            {
+                SelectedScriptRealPath = CurMainTree?.Script?.RealPath
+            };
+            foreach (ProjectTreeItemModel root in MainTreeItems)
+                RecursiveCaptureExpanded(root, state.ExpandedKeys);
+            return state;
+        }
+
+        private static void RecursiveCaptureExpanded(ProjectTreeItemModel item, HashSet<string> expandedKeys)
+        {
+            if (item.IsExpanded)
+                expandedKeys.Add($"{item.Script.Level}|{item.Script.RealPath}");
+            foreach (ProjectTreeItemModel child in item.Children)
+                RecursiveCaptureExpanded(child, expandedKeys);
+        }
+
+        /// <summary>
+        /// Apply collapsed/expanded state to the current tree after it has been rebuilt.
+		/// - expands matching nodes
+		/// - re-selects the saved script (or falls back to the default project root)
+		/// - bounces IsSelected on the target so WPF's BringIntoViewBehavior scrolls it into view.
+        /// </summary>
+        private void RestoreMainTreeState(TreeViewState state)
+        {
+            // Restore expanded/collapsed state of every node.
+            foreach (ProjectTreeItemModel root in MainTreeItems)
+                RecursiveRestoreExpanded(root, state.ExpandedKeys);
+
+            // Re-select the previously selected script (if it still exists).
+            ProjectTreeItemModel? target = null;
+            if (state.SelectedScriptRealPath != null)
+            {
+                foreach (ProjectTreeItemModel root in MainTreeItems)
+                {
+                    target = ProjectTreeItemModel.FindScriptByRealPath(root, state.SelectedScriptRealPath);
+                    if (target != null)
+                        break;
+                }
+            }
+
+            // Fall back to default project root if the script no longer exists.
+            if (target == null)
+            {
+                string defaultProjectName = Global.Setting?.Project.DefaultProject ?? string.Empty;
+                target = MainTreeItems
+                    .FirstOrDefault(x => defaultProjectName.Equals(
+                        x.Script.Project.ProjectName, StringComparison.OrdinalIgnoreCase))
+                    ?? MainTreeItems.LastOrDefault();
+            }
+
+            if (target == null)
+                return;
+
+            // Ensure every ancestor of the target is expanded so that WPF's
+            // virtualizing panel will realize the target's container.
+            target.ExpandAncestors();
+
+            CurMainTree = target;
+
+            // Use ContextIdle priority so the Normal-priority tree-expansion
+            // notifications (marshalled from this background thread) are fully
+            // processed and rendered before the script panel updates.
+            // Dispatcher.Invoke uses Send priority and would jump the queue,
+            // showing the script interface panel while the tree is still blank.
+            Application.Current?.Dispatcher?.BeginInvoke(new Action(() =>
+            {
+                DisplayScript(target.Script);
+                // Bounce IsSelected after DisplayScript so BringIntoViewBehavior
+                // fires once the script panel is already showing.
+                target.IsSelected = false;
+                target.IsSelected = true;
+                // Scroll the selected item into view (handles off-screen items
+                // that BringIntoViewBehavior would not be able to reach becuase of virtualization).
+                BringTreeSelectionIntoViewAction?.Invoke();
+            }), System.Windows.Threading.DispatcherPriority.ContextIdle);
+        }
+
+        private static void RecursiveRestoreExpanded(ProjectTreeItemModel item, HashSet<string> expandedKeys)
+        {
+            item.IsExpanded = expandedKeys.Contains($"{item.Script.Level}|{item.Script.RealPath}");
+            foreach (ProjectTreeItemModel child in item.Children)
+                RecursiveRestoreExpanded(child, expandedKeys);
+        }
+        #endregion
+
+        public Task StartLoadingProjects(bool refreshProjectEntries, bool quiet,
+                                         TreeViewState? stateToRestore = null)
         {
             if (IsProjectsLoading())
                 return Task.CompletedTask;
@@ -1065,17 +1166,6 @@ namespace PEBakery.Core.ViewModels
                             MainTreeItems.Add(projectRoot);
                         }
 
-                        // Select default project
-                        // If default project is not set, use last project (Some PE projects starts with 'W' from Windows)
-                        string defaultProjectName = setting.Project.DefaultProject;
-                        ProjectTreeItemModel? itemModel = MainTreeItems
-                            .FirstOrDefault(x => defaultProjectName.Equals(x.Script.Project.ProjectName, StringComparison.OrdinalIgnoreCase));
-                        CurMainTree = itemModel ?? MainTreeItems.Last();
-                        CurMainTree.IsExpanded = true;
-                        Application.Current?.Dispatcher?.Invoke(() => { DisplayScript(CurMainTree.Script); });
-
-                        Global.Logger.SystemWrite(new LogInfo(LogState.Info, $"Projects [{string.Join(", ", Global.Projects.Select(x => x.ProjectName))}] loaded"));
-
                         watch.Stop();
                         double t = watch.Elapsed.TotalMilliseconds / 1000.0;
                         string msg;
@@ -1084,12 +1174,32 @@ namespace PEBakery.Core.ViewModels
                             double cachePercent = (double)(stage1CachedCount + stage2CachedCount) * 100 / (scriptCount + 2 * linkCount);
                             cachePercent = Math.Min(cachePercent, 100);
                             msg = $"{scriptCount + linkCount} scripts loaded ({t:0.#}s) - {cachePercent:0.#}% cached";
-                            StatusBarText = msg;
                         }
                         else
                         {
                             msg = $"{scriptCount + linkCount} scripts loaded ({t:0.#}s)";
-                            StatusBarText = msg;
+                            
+                        }
+                        StatusBarText = msg;
+
+                        // Restore script selection or select default project if
+						// nothing is saved or the selction no longer exists.
+                        string defaultProjectName = setting.Project.DefaultProject;
+                        ProjectTreeItemModel? itemModel = MainTreeItems
+                            .FirstOrDefault(x => defaultProjectName.Equals(x.Script.Project.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+                        if (stateToRestore != null)
+                        {
+                            ScriptDescriptionText = "Restoring tree state...";
+                            RestoreMainTreeState(stateToRestore);
+                        }
+                        else
+                        {
+                            CurMainTree = itemModel ?? MainTreeItems.Last();
+                            CurMainTree.IsExpanded = true;
+                            Application.Current?.Dispatcher?.BeginInvoke(
+                                new Action(() => DisplayScript(CurMainTree.Script)),
+                                System.Windows.Threading.DispatcherPriority.ContextIdle);
                         }
 
                         Global.Logger.SystemWrite(new LogInfo(LogState.Info, msg));
@@ -1346,6 +1456,15 @@ namespace PEBakery.Core.ViewModels
             node.ParentCheckedPropagation();
             UpdateTreeViewIcon(node);
             DisplayScript(node.Script);
+
+            // Bounce IsSelected so BringIntoViewBehavior scrolls the refreshed
+            // script back into view and re-highlights it.
+            Application.Current?.Dispatcher?.BeginInvoke(new Action(() =>
+            {
+                node.IsSelected = false;
+                node.IsSelected = true;
+                BringTreeSelectionIntoViewAction?.Invoke();
+            }), System.Windows.Threading.DispatcherPriority.ContextIdle);
         }
         #endregion
 

--- a/PEBakery.Core/ViewModels/ProjectTreeViewModel.cs
+++ b/PEBakery.Core/ViewModels/ProjectTreeViewModel.cs
@@ -26,6 +26,7 @@
 */
 
 using MahApps.Metro.IconPacks;
+using PEBakery.Core;
 using PEBakery.Ini;
 using System;
 using System.Collections.Generic;
@@ -38,6 +39,62 @@ using System.Windows.Input;
 
 namespace PEBakery.Core.ViewModels
 {
+    #region TreeViewState
+    /// <summary>
+    /// A lightweight snapshot of the main tree view's visual state. Expanded nodes + paths
+    /// are stored as "Level|RealPath" composite keys. '~' is the list separator.
+	///
+    /// The Level component distinguishes directory nodes that share the same RealPath
+    /// but appear at different positions in the tree (ex. a folder that contains
+    ///	scripts at both Level=1 and Level=7 appears as two separate nodes).
+	///
+	/// Used to save and restore the tree across project/script refreshes and application restarts.
+    /// </summary>
+    public class TreeViewState
+    {
+        /// <summary>RealPath of the selected script, or null if nothing is selected.</summary>
+        public string? SelectedScriptRealPath { get; set; }
+
+        /// <summary>
+        /// "Level|RealPath" composite keys for every node whose IsExpanded was true.
+        /// Using a composite key prevents a folder that appears at multiple levels from
+        /// being incorrectly expanded at every level when only one was saved.
+        /// </summary>
+        public HashSet<string> ExpandedKeys { get; set; } =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        private static string MakeKey(Script sc) => $"{sc.Level}|{sc.RealPath}";
+
+        public void SaveToSetting(Setting.InterfaceSetting iface)
+        {
+            iface.MainTreeSelectedScript = SelectedScriptRealPath ?? string.Empty;
+            iface.MainTreeExpandedNodes  = string.Join("~", ExpandedKeys);
+        }
+
+        /// <summary>
+        /// Builds a TreeViewState from previously saved interface settings.
+		/// Returns null when no tree state has been saved yet (first run)
+        /// so the caller can fall back to the default behaviour.
+        /// </summary>
+        public static TreeViewState? LoadFromSetting(Setting.InterfaceSetting iface)
+        {
+            bool hasSelected = !string.IsNullOrEmpty(iface.MainTreeSelectedScript);
+            bool hasExpanded = !string.IsNullOrEmpty(iface.MainTreeExpandedNodes);
+
+            if (!hasSelected && !hasExpanded)
+                return null; // First run — nothing saved yet.
+
+            return new TreeViewState
+            {
+                SelectedScriptRealPath = hasSelected ? iface.MainTreeSelectedScript : null,
+                ExpandedKeys = new HashSet<string>(
+                    iface.MainTreeExpandedNodes.Split('~', StringSplitOptions.RemoveEmptyEntries),
+                    StringComparer.OrdinalIgnoreCase)
+            };
+        }
+    }
+    #endregion
+
     #region ProjectTreeViewModel
     public class ProjectTreeItemModel : ViewModelBase
     {
@@ -65,6 +122,34 @@ namespace PEBakery.Core.ViewModels
             {
                 _isExpanded = value;
                 OnPropertyUpdate(nameof(IsExpanded));
+            }
+        }
+
+        /// <summary>
+        /// Bound TwoWay to TreeViewItem.IsSelected via the ItemContainerStyle.
+        /// Setting this to true causes WPF (via BringIntoViewBehavior) to scroll
+        /// the item into view.  Always bounce false->true to guarantee the transition
+        /// even when the same item is re-selected after a tree rebuild.
+        /// </summary>
+        private bool _isSelected = false;
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set => SetProperty(ref _isSelected, value);
+        }
+
+        /// <summary>
+        /// Walks up the Parent chain and sets IsExpanded = true on every ancestor.
+        /// Must be called before requesting a BringIntoView scroll so that WPF's
+        /// virtualizing panel can realize the target item's container.
+        /// </summary>
+        public void ExpandAncestors()
+        {
+            ProjectTreeItemModel? ancestor = Parent;
+            while (ancestor != null)
+            {
+                ancestor.IsExpanded = true;
+                ancestor = ancestor.Parent;
             }
         }
 

--- a/PEBakery/WPF/MainWindow.xaml
+++ b/PEBakery/WPF/MainWindow.xaml
@@ -472,6 +472,12 @@
             <Grid Grid.Column="0"
                   Margin="0, 0, 8, 0"
                   Visibility="{Binding NormalInterfaceVisibility}">
+                <!-- We cannot use VirtualizingStackPanel.VirtualizationMode="Recycling" in MainTreeView
+                     becuase it breaks BringIntoView() when a  large number of nodes are expanded.
+		     Disabling Virtualization works, but can result in a noticable 3-5 second delay
+		     reloading the MainTreeView when a large number of scripts are expanded.
+		     Using Standard mode with our callbacks eliminates the delay and allows BringIntoView() to function.
+                -->
                 <TreeView x:Name="MainTreeView"
                           Background="{Binding TreePanelBackground, Converter={StaticResource ColorToSolidColorBrushConverter}, FallbackValue=Gray}"
                           Foreground="{Binding TreePanelForeground, Converter={StaticResource ColorToSolidColorBrushConverter}, FallbackValue=Black}"
@@ -483,8 +489,9 @@
                           Unloaded="MainTreeView_Unloaded"
                           SelectedItemChanged="MainTreeView_SelectedItemChanged"
                           PreviewMouseRightButtonDown="MainTreeView_PreviewMouseRightButtonDown"
-                          VirtualizingStackPanel.IsVirtualizing="True"
-                          VirtualizingStackPanel.VirtualizationMode="Recycling">
+                          TreeViewItem.Expanded="MainTreeView_TreeItemExpanded"
+                          TreeViewItem.Collapsed="MainTreeView_TreeItemCollapsed"
+                          VirtualizingStackPanel.IsVirtualizing="True">
                     <TreeView.ItemTemplate>
                         <HierarchicalDataTemplate DataType="vm:ProjectTreeItemModel"
                                                   ItemsSource="{Binding Children}">
@@ -648,8 +655,14 @@
                     </TreeView.ItemTemplate>
                     <TreeView.ItemContainerStyle>
                         <Style TargetType="TreeViewItem">
-                            <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
-                            <!-- <Setter Property="IsSelected" Value="{Binding Build, Mode=TwoWay}" /> -->
+                            <!-- TreeViewItem.Expanded/Collapsed routed event handlers below
+                                 are kept as a belt-and-suspenders guard but TwoWay is the main path. -->
+                            <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                            <!-- Bouncing IsSelected false->true after a tree rebuild causes
+                                 BringIntoViewBehavior to fire TreeViewItem.Selected, which
+                                 calls BringIntoView() to scroll the item into view. -->
+                            <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
+                            <Setter Property="cc:BringIntoViewBehavior.BringIntoView" Value="True"/>
                             <Setter Property="Foreground" Value="{Binding Path=DataContext.TreePanelForeground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}, Converter={StaticResource ColorToSolidColorBrushConverter}, Mode=OneWay, FallbackValue=Black}"/>
                         </Style>
                     </TreeView.ItemContainerStyle>

--- a/PEBakery/WPF/MainWindow.xaml.cs
+++ b/PEBakery/WPF/MainWindow.xaml.cs
@@ -42,7 +42,9 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Shell;
+using System.Reflection;
 
 namespace PEBakery.WPF
 {
@@ -74,8 +76,13 @@ namespace PEBakery.WPF
             // Setup SystemLogHasIssue event handler
             Model.SubscribeSystemLogUpdateEvent();
 
-            // Load Projects
-            Model.StartLoadingProjects(false, false);
+            // Setup the scroll-into-view callback.
+            Model.BringTreeSelectionIntoViewAction = BringSelectedTreeItemIntoView;
+
+            // Load Projects — pass any previously-saved tree state so the selection
+            // and expanded nodes are restored once loading is complete.
+            TreeViewState? savedTreeState = TreeViewState.LoadFromSetting(Global.Setting.Interface);
+            Model.StartLoadingProjects(false, false, savedTreeState);
 
             // Read Window Layout/Position
             ReadLayoutFromSetting();
@@ -199,7 +206,8 @@ namespace PEBakery.WPF
             // Force update of script interface
             ProjectRefreshButton.Focus();
 
-            Model.StartLoadingProjects(true, false);
+            TreeViewState treeState = Model.CaptureMainTreeState();
+            Model.StartLoadingProjects(true, false, treeState);
         }
 
         private void SettingWindowCommand_Executed(object? sender, ExecutedRoutedEventArgs e)
@@ -217,7 +225,8 @@ namespace PEBakery.WPF
                 // Refresh Projects
                 if (svModel.NeedProjectRefresh)
                 {
-                    Model.StartLoadingProjects(true, false);
+                    TreeViewState treeState = Model.CaptureMainTreeState();
+                    Model.StartLoadingProjects(true, false, treeState);
                 }
                 else
                 {
@@ -941,6 +950,147 @@ namespace PEBakery.WPF
         }
 
         /// <summary>
+        /// Handles TreeViewItem.Expanded routed events bubbled up to the TreeView.
+        /// Belt-and-suspenders: the TwoWay binding handles this in most cases, but
+        /// the event handler ensures correctness if the binding ever fires late.
+        /// </summary>
+        private void MainTreeView_TreeItemExpanded(object sender, RoutedEventArgs e)
+        {
+            if (e.OriginalSource is TreeViewItem { DataContext: ProjectTreeItemModel model })
+                model.IsExpanded = true;
+        }
+
+        private void MainTreeView_TreeItemCollapsed(object sender, RoutedEventArgs e)
+        {
+            if (e.OriginalSource is TreeViewItem { DataContext: ProjectTreeItemModel model })
+                model.IsExpanded = false;
+        }
+
+        /// <summary>
+        /// Scroll the currently-selected tree item into view after a tree state restore
+        /// or project refresh.
+        ///
+        /// Why not disable virtualization:
+        ///   Calling VirtualizingPanel.SetIsVirtualizing(false) + UpdateLayout() forces
+        ///   WPF to instantiate containers for every expanded node in the entire tree at
+        ///   once. With 250+ scripts fully expanded this causes a 3-5 second UI freeze.
+        ///
+        /// To avoid this we walk the root-to-target path one level at a time:
+        ///   1. Build the path upfront using the model's Parent chain.
+        ///   2. At each level, call UpdateLayout() to flush any pending scroll from the
+        ///      previous BringIntoView() call, then try to get the container.
+        ///   3. If the container isn't realized (item is off-screen), ask the
+        ///      VirtualizingStackPanel to scroll to that index via BringIndexIntoView(),
+        ///      then UpdateLayout() to realize just the items now in the viewport.
+        ///   4. Call BringIntoView() on the found container, then descend.
+        ///
+        ///   At each step only the containers visible in the viewport are created —
+        ///   O (viewport_items) per level, not O (total_items).
+        /// </summary>
+        private void BringSelectedTreeItemIntoView()
+        {
+            if (Model.CurMainTree is not ProjectTreeItemModel target)
+                return;
+
+            // Build root-first path via the Parent chain.
+            List<ProjectTreeItemModel> path = new List<ProjectTreeItemModel>();
+            for (ProjectTreeItemModel? node = target; node != null; node = node.Parent)
+                path.Insert(0, node);
+
+            ItemsControl container = MainTreeView;
+
+            for (int depth = 0; depth < path.Count; depth++)
+            {
+                // Flush pending layout (including any ScrollViewer scroll queued by
+                // BringIntoView() in the previous iteration).
+                container.UpdateLayout();
+
+                // Find the index of this depth's node in the container.
+                ProjectTreeItemModel depthTarget = path[depth];
+                int index = -1;
+                for (int i = 0; i < container.Items.Count; i++)
+                {
+                    if (ReferenceEquals(container.Items[i], depthTarget))
+                    {
+                        index = i;
+                        break;
+                    }
+                }
+                if (index < 0) return;
+
+                // If the item is off-screen its container hasn't been created yet.
+                // BringIndexIntoView asks the VirtualizingStackPanel to scroll that
+                // index into the viewport without needing an existing container.
+                if (container.ItemContainerGenerator.ContainerFromIndex(index) is not TreeViewItem tvi)
+                {
+                    VirtualizingStackPanel? vsp = GetItemsPanel(container);
+                    if (vsp != null)
+                        BringIndexIntoViewInternal(vsp, index);
+                    container.UpdateLayout();
+
+                    if (container.ItemContainerGenerator.ContainerFromIndex(index) is not TreeViewItem tvi2)
+                        return;
+                    tvi = tvi2;
+                }
+
+                // Scroll this item into view.  BringIntoView() raises RequestBringIntoView
+                // which the ScrollViewer processes asynchronously (marks itself dirty).
+                // The UpdateLayout() at the top of the NEXT iteration flushes that scroll.
+                tvi.BringIntoView();
+
+                if (depth == path.Count - 1)
+                {
+                    tvi.Focus();
+                    return;
+                }
+
+                container = tvi;
+            }
+        }
+
+        /// <summary>
+        /// Returns the VirtualizingStackPanel inside container's
+        /// items presenter.  Returns null if the panel hasn't been created yet (e.g. the
+        /// container hasn't been expanded) or if the container doesn't use a VSP.
+        /// </summary>
+        private static VirtualizingStackPanel? GetItemsPanel(ItemsControl container)
+        {
+            container.UpdateLayout();
+            ItemsPresenter? presenter = FindVisualChild<ItemsPresenter>(container);
+            if (presenter == null) return null;
+            presenter.UpdateLayout();
+            return FindVisualChild<VirtualizingStackPanel>(presenter);
+        }
+
+        /// <summary>
+        /// VirtualizingStackPanel.BringIndexIntoView is protected, so
+        /// use reflection for calling it externally.
+        /// </summary>
+        private static readonly MethodInfo? _bringIndexIntoViewMethod =
+            typeof(VirtualizingStackPanel).GetMethod(
+                "BringIndexIntoView",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null, new[] { typeof(int) }, null);
+
+        private static void BringIndexIntoViewInternal(VirtualizingStackPanel vsp, int index)
+        {
+            _bringIndexIntoViewMethod?.Invoke(vsp, new object[] { index });
+        }
+
+        /// <summary>Depth-first search for the first visual descendant of type T.</summary>
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T typed) return typed;
+                T? found = FindVisualChild<T>(child);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Used to ensure pressing 'Space' to toggle TreeView's checkbox.
         /// </summary>
         private void MainTreeView_KeyDown(object sender, KeyEventArgs e)
@@ -1041,6 +1191,10 @@ namespace PEBakery.WPF
                 await Task.Delay(500);
 
             Global.Cleanup();
+
+            // Save the tree state so it can be restored on next startup.
+            TreeViewState treeState = Model.CaptureMainTreeState();
+            treeState.SaveToSetting(Global.Setting.Interface);
 
             // Save Main Window Layout/Position
             WriteLayoutToSetting();


### PR DESCRIPTION
@ied206 
This PR saves the main project tree state and restores it after a refresh or application close.

Script tree state is preserved when a user clicks the main Refresh button, or executes `System,RefreshAllScripts`. 
- Expanded Nodes
- Currently selected script

State is stored in the `[Interface]` section of `PEBakery.ini` on application close and restored when PEBakery is launched.
`MainTreeExpandedNodes` - '~' delimited list of expanded nodes stored as (ScriptLevel|RealPath)
`MainTreeSelectedScript` - Last selected script (RealPath)

Notes:
- Missing saved items are simply skipped on load/refresh
- If both setting fields are null/empty (first run) fall back to original default behavior and display the default project.

Challenges were fighting with the VirtualizingPanel in Recycling mode which kept breaking `BringIntoView()` when a large number of nodes was expanded and the selected script was further down the tree. I initially tried simply disabling Virtualization, however when a large number of nodes were expanded (PhoenixPE has 250+ scripts) there was a noticeable 3-5 second UI freeze while the tree was recreated. I did not find this acceptable, so as a compromise VirtulizingPanel is in standard node and scrolling is resolved by walking the tree so the container is realized. This doubles the amount of code required, vs no virtualization and letting the binding do all the work, but maximizes performance.

Feel free to make any changes or additions as you see fit.

Closes #207 